### PR TITLE
[Feat] 기본적인 라우터 설정 및 테스트 페이지 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,18 @@
+import { Routes, Route } from 'react-router'
 import './App.css'
+import Landing from './pages/Landing'
+import Test from './pages/Test'
 
 function App() {
-  return <div>template</div>
+  return (
+    <Routes>
+      {/* 랜딩 */}
+      <Route path="/" element={<Landing />} />
+
+      {/* 테스트 */}
+      <Route path="/test" element={<Test />} />
+    </Routes>
+  )
 }
 
 export default App

--- a/src/components/test/TestWrapper.tsx
+++ b/src/components/test/TestWrapper.tsx
@@ -1,0 +1,15 @@
+interface TestWrapperProps {
+  label: string
+  children: React.ReactNode
+}
+
+function TestWrapper({ label, children }: TestWrapperProps) {
+  return (
+    <div className="flex flex-col items-center gap-4 rounded-xl border-4 border-solid border-pink-300 bg-white p-8">
+      <h3 className="text-2xl font-medium">{label}</h3>
+      <div>{children}</div>
+    </div>
+  )
+}
+
+export default TestWrapper

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from 'react'
-
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router'
 
 import './index.css'
 import App from './App.tsx'
@@ -20,7 +20,9 @@ async function enableMocking() {
 enableMocking().then(() => {
   createRoot(document.getElementById('root')!).render(
     <StrictMode>
-      <App />
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
     </StrictMode>
   )
 })

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -1,0 +1,9 @@
+function Landing() {
+  return (
+    <div>
+      <h1>커뮤니티 파트 랜딩 페이지 입니다!</h1>
+    </div>
+  )
+}
+
+export default Landing

--- a/src/pages/Test.tsx
+++ b/src/pages/Test.tsx
@@ -1,0 +1,15 @@
+function Test() {
+  return (
+    <div className="flex h-dvh flex-col items-center gap-10 overflow-y-auto bg-pink-100 p-10">
+      <h1 className="text-4xl font-bold text-gray-700">
+        Test 페이지 ^~^ (UI 확인용)
+      </h1>
+      <div className="flex flex-col items-center gap-4 rounded-xl border-4 border-solid border-pink-300 bg-white p-8">
+        <h3 className="text-2xl font-medium">컴포넌트 이름 (EX. Button)</h3>
+        <div>(여기에 컴포넌트 추가!)</div>
+      </div>
+    </div>
+  )
+}
+
+export default Test

--- a/src/pages/Test.tsx
+++ b/src/pages/Test.tsx
@@ -1,13 +1,16 @@
+import TestWrapper from '../components/test/TestWrapper'
+
 function Test() {
   return (
     <div className="flex h-dvh flex-col items-center gap-10 overflow-y-auto bg-pink-100 p-10">
       <h1 className="text-4xl font-bold text-gray-700">
         Test 페이지 ^~^ (UI 확인용)
       </h1>
-      <div className="flex flex-col items-center gap-4 rounded-xl border-4 border-solid border-pink-300 bg-white p-8">
-        <h3 className="text-2xl font-medium">컴포넌트 이름 (EX. Button)</h3>
-        <div>(여기에 컴포넌트 추가!)</div>
-      </div>
+      <TestWrapper label="테스트">
+        <button className="rounded-md bg-pink-100 px-4 py-2 text-gray-700 hover:bg-pink-200">
+          test
+        </button>
+      </TestWrapper>
     </div>
   )
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,9 +1,0 @@
-const HomePage = () => {
-  return (
-    <div>
-      <h1>Home Page</h1>
-    </div>
-  )
-}
-
-export default HomePage


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #16

## ✨ 변경 내용
<!-- 변경한 내용을 간략하게 설명해주세요. -->
- UI 확인용 테스트 페이지 추가
- 랜딩 및 테스트 페이지 라우터 설정

## 📸 스크린샷(선택)
<!-- 스크린샷이 있다면 첨부해주세요. -->
<img width="1435" height="756" alt="image" src="https://github.com/user-attachments/assets/c82aa12d-2438-4ae6-a156-6c823b6cf8d2" />


## 📚 참고사항
<!-- 참고할 사항이 있다면 적어주세요. -->
**Test** 페이지에 추가할 컴포넌트는 아래 예제처럼 `TestWrapper` 컴포넌트로 감싸주세요!
**props**로 `label`에 컴포넌트 이름을, `TestWrapper` 컴포넌트의 자식 요소로 본인이 추가하고 싶은 컴포넌트를 추가하면 됩니다!
방법 헷갈리시면 저한테 말씀해주세요
```
<TestWrapper label="Button 컴포넌트">
  <Button>Button Text</Button>
</TestWrapper>
```
