### PR TITLE
[Feat] 게시글 카드 컴포넌트 구현

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,1 +1,0 @@
-@import 'tailwindcss';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
 import { Routes, Route } from 'react-router'
-import './App.css'
 import Landing from './pages/Landing'
 import Test from './pages/Test'
 

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -1,5 +1,6 @@
 import { ThumbsUp } from 'lucide-react'
 import { postCardData } from '../mocks/data/postCardData'
+import { formatCreatedTime } from '../utils/time'
 
 function PostCard({
   category = postCardData.categoryName,
@@ -10,7 +11,10 @@ function PostCard({
   commentCount = postCardData.commentCount,
   authorName = postCardData.author.nickname,
   authorProfileImg = postCardData.author.profileImgUrl,
+  createdAt = postCardData.createdAt,
 }) {
+  const dateString = formatCreatedTime(createdAt)
+
   return (
     <div className="hover:bg-primary-50 flex h-56 w-full cursor-pointer gap-10 rounded-xl p-6 transition-all duration-200">
       <div className="flex w-full flex-col justify-between">
@@ -52,7 +56,7 @@ function PostCard({
             </div>
 
             {/* 작성 시기 */}
-            <span className="text-xs text-gray-400">1시간 전</span>
+            <span className="text-xs text-gray-400">{dateString}</span>
           </div>
         </div>
       </div>

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -2,52 +2,61 @@ import { ThumbsUp } from 'lucide-react'
 
 function PostCard() {
   return (
-    <div className="box-border flex h-56 flex-col justify-between border p-6">
-      <div className="flex flex-col gap-3">
-        {/* 카테고리 */}
-        <span className="text-xs text-gray-600">구인/협업</span>
+    <div className="hover:bg-primary-50 flex h-56 w-full cursor-pointer gap-10 rounded-xl p-6 transition-all duration-200">
+      <div className="flex w-full flex-col justify-between">
+        <div className="flex flex-col gap-3">
+          {/* 카테고리 */}
+          <span className="text-xs text-gray-600">구인/협업</span>
 
-        {/* 제목 */}
-        <h3 className="truncate text-lg font-semibold text-black">
-          데이터 분석 프로젝트 구합니다!
-        </h3>
+          {/* 제목 */}
+          <h3 className="truncate text-lg font-semibold text-black">
+            데이터 분석 프로젝트 구합니다!
+          </h3>
 
-        {/* 내용 (한 줄) */}
-        <p className="truncate text-sm text-gray-400">
-          저는 완전 기초인데 혹시 같이 프로젝트 만드실분 계신가요?!
-        </p>
-      </div>
-
-      <div className="flex justify-between">
-        {/* 좋아요 / 댓글 / 조회 수 */}
-        <div className="flex gap-3">
-          <div className="flex items-center gap-1 text-gray-500">
-            <ThumbsUp className="size-5" />
-            <span className="text-xs">좋아요 156</span>
-          </div>
-          <div className="flex items-center gap-1 text-gray-500">
-            <span className="text-xs">댓글 6</span>
-          </div>
-          <div className="flex items-center gap-1 text-gray-500">
-            <span className="text-xs">조회수 60</span>
-          </div>
+          {/* 내용 (한 줄) */}
+          <p className="truncate text-sm text-gray-400">
+            저는 완전 기초인데 혹시 같이 프로젝트 만드실분 계신가요?!
+          </p>
         </div>
 
-        <div className="flex items-center gap-2">
-          {/* 프로필 사진 / 이름 */}
-          <div className="flex items-center gap-1">
-            <img
-              src="https://picsum.photos/200/300"
-              alt="조조야-profile-image"
-              className="size-6 rounded-full object-cover"
-            />
-            <span className="text-xs text-gray-600">조조야</span>
+        <div className="flex w-full justify-between">
+          {/* 좋아요 / 댓글 / 조회 수 */}
+          <div className="flex gap-3">
+            <div className="flex items-center gap-1 text-gray-500">
+              <ThumbsUp className="size-5" />
+              <span className="text-xs">좋아요 156</span>
+            </div>
+            <div className="flex items-center gap-1 text-gray-500">
+              <span className="text-xs">댓글 6</span>
+            </div>
+            <div className="flex items-center gap-1 text-gray-500">
+              <span className="text-xs">조회수 60</span>
+            </div>
           </div>
 
-          {/* 작성 시기 */}
-          <span className="text-xs text-gray-400">1시간 전</span>
+          <div className="flex items-center gap-2">
+            {/* 프로필 사진 / 이름 */}
+            <div className="flex items-center gap-1">
+              <img
+                src="https://picsum.photos/200/300"
+                alt="조조야-profile-image"
+                className="size-6 rounded-full object-cover"
+              />
+              <span className="text-xs text-gray-600">조조야</span>
+            </div>
+
+            {/* 작성 시기 */}
+            <span className="text-xs text-gray-400">1시간 전</span>
+          </div>
         </div>
       </div>
+
+      {/* 게시글 이미지 */}
+      <img
+        src="https://picsum.photos/600/400"
+        alt="post-image"
+        className="rounded-lg object-cover"
+      />
     </div>
   )
 }

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -2,32 +2,34 @@ import { ThumbsUp } from 'lucide-react'
 
 function PostCard() {
   return (
-    <div>
-      {/* 카테고리 */}
-      <span className="text-xs text-gray-600">구인/협업</span>
+    <div className="box-border flex h-56 flex-col justify-between border p-6">
+      <div className="flex flex-col gap-3">
+        {/* 카테고리 */}
+        <span className="text-xs text-gray-600">구인/협업</span>
 
-      {/* 제목 */}
-      <h3 className="truncate text-lg font-semibold text-black">
-        데이터 분석 프로젝트 구합니다!
-      </h3>
+        {/* 제목 */}
+        <h3 className="truncate text-lg font-semibold text-black">
+          데이터 분석 프로젝트 구합니다!
+        </h3>
 
-      {/* 내용 (한 줄) */}
-      <p className="truncate text-sm text-gray-400">
-        저는 완전 기초인데 혹시 같이 프로젝트 만드실분 계신가요?!
-      </p>
+        {/* 내용 (한 줄) */}
+        <p className="truncate text-sm text-gray-400">
+          저는 완전 기초인데 혹시 같이 프로젝트 만드실분 계신가요?!
+        </p>
+      </div>
 
-      <div>
+      <div className="flex justify-between">
         {/* 좋아요 / 댓글 / 조회 수 */}
-        <div>
+        <div className="flex gap-3">
           <div className="flex items-center gap-1 text-gray-500">
             <ThumbsUp className="size-5" />
-            <span>좋아요 156</span>
+            <span className="text-xs">좋아요 156</span>
           </div>
-          <div className="flex items-center gap-1">
-            <span>댓글 6</span>
+          <div className="flex items-center gap-1 text-gray-500">
+            <span className="text-xs">댓글 6</span>
           </div>
-          <div className="flex items-center gap-1">
-            <span>조회수 60</span>
+          <div className="flex items-center gap-1 text-gray-500">
+            <span className="text-xs">조회수 60</span>
           </div>
         </div>
 
@@ -35,9 +37,9 @@ function PostCard() {
           {/* 프로필 사진 / 이름 */}
           <div className="flex items-center gap-1">
             <img
-              src=""
+              src="https://picsum.photos/200/300"
               alt="조조야-profile-image"
-              className="size-6 rounded-full"
+              className="size-6 rounded-full object-cover"
             />
             <span className="text-xs text-gray-600">조조야</span>
           </div>

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -1,22 +1,28 @@
 import { ThumbsUp } from 'lucide-react'
+import { postCardData } from '../mocks/data/postCardData'
 
-function PostCard() {
+function PostCard({
+  category = postCardData.categoryName,
+  title = postCardData.title,
+  contentPreview = postCardData.contentPreview,
+  likeCount = postCardData.likeCount,
+  viewCount = postCardData.viewCount,
+  commentCount = postCardData.commentCount,
+  authorName = postCardData.author.nickname,
+  authorProfileImg = postCardData.author.profileImgUrl,
+}) {
   return (
     <div className="hover:bg-primary-50 flex h-56 w-full cursor-pointer gap-10 rounded-xl p-6 transition-all duration-200">
       <div className="flex w-full flex-col justify-between">
         <div className="flex flex-col gap-3">
           {/* 카테고리 */}
-          <span className="text-xs text-gray-600">구인/협업</span>
+          <span className="text-xs text-gray-600">{category}</span>
 
           {/* 제목 */}
-          <h3 className="truncate text-lg font-semibold text-black">
-            데이터 분석 프로젝트 구합니다!
-          </h3>
+          <h3 className="truncate text-lg font-semibold text-black">{title}</h3>
 
           {/* 내용 (한 줄) */}
-          <p className="truncate text-sm text-gray-400">
-            저는 완전 기초인데 혹시 같이 프로젝트 만드실분 계신가요?!
-          </p>
+          <p className="truncate text-sm text-gray-400">{contentPreview}</p>
         </div>
 
         <div className="flex w-full justify-between">
@@ -24,13 +30,13 @@ function PostCard() {
           <div className="flex gap-3">
             <div className="flex items-center gap-1 text-gray-500">
               <ThumbsUp className="size-5" />
-              <span className="text-xs">좋아요 156</span>
+              <span className="text-xs">좋아요 {likeCount}</span>
             </div>
             <div className="flex items-center gap-1 text-gray-500">
-              <span className="text-xs">댓글 6</span>
+              <span className="text-xs">댓글 {commentCount}</span>
             </div>
             <div className="flex items-center gap-1 text-gray-500">
-              <span className="text-xs">조회수 60</span>
+              <span className="text-xs">조회수 {viewCount}</span>
             </div>
           </div>
 
@@ -38,11 +44,11 @@ function PostCard() {
             {/* 프로필 사진 / 이름 */}
             <div className="flex items-center gap-1">
               <img
-                src="https://picsum.photos/200/300"
-                alt="조조야-profile-image"
+                src={authorProfileImg}
+                alt="author-profile-image"
                 className="size-6 rounded-full object-cover"
               />
-              <span className="text-xs text-gray-600">조조야</span>
+              <span className="text-xs text-gray-600">{authorName}</span>
             </div>
 
             {/* 작성 시기 */}

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -1,0 +1,48 @@
+import { ThumbsUp } from 'lucide-react'
+
+function PostCard() {
+  return (
+    <div>
+      {/* 카테고리 */}
+      <div>구인/협업</div>
+
+      {/* 제목 */}
+      <h3>데이터 분석 프로젝트 구합니다!</h3>
+
+      {/* 내용 (한 줄) */}
+      <p>저는 완전 기초인데 혹시 같이 프로젝트 만드실분 계신가요?!</p>
+
+      <div>
+        {/* 좋아요 / 댓글 / 조회 수 */}
+        <div>
+          <div>
+            <ThumbsUp className="size-5 text-gray-500" />
+            <span>좋아요</span>
+            <span>156</span>
+          </div>
+          <div>
+            <span>댓글</span>
+            <span>6</span>
+          </div>
+          <div>
+            <span>조회수</span>
+            <span>60</span>
+          </div>
+        </div>
+
+        <div>
+          {/* 프로필 사진 / 이름 */}
+          <div>
+            <img src="" alt="" />
+            <span>조조야</span>
+          </div>
+
+          {/* 작성 시기 */}
+          <span>1시간 전</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default PostCard

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -4,41 +4,46 @@ function PostCard() {
   return (
     <div>
       {/* 카테고리 */}
-      <div>구인/협업</div>
+      <span className="text-xs text-gray-600">구인/협업</span>
 
       {/* 제목 */}
-      <h3>데이터 분석 프로젝트 구합니다!</h3>
+      <h3 className="truncate text-lg font-semibold text-black">
+        데이터 분석 프로젝트 구합니다!
+      </h3>
 
       {/* 내용 (한 줄) */}
-      <p>저는 완전 기초인데 혹시 같이 프로젝트 만드실분 계신가요?!</p>
+      <p className="truncate text-sm text-gray-400">
+        저는 완전 기초인데 혹시 같이 프로젝트 만드실분 계신가요?!
+      </p>
 
       <div>
         {/* 좋아요 / 댓글 / 조회 수 */}
         <div>
-          <div>
-            <ThumbsUp className="size-5 text-gray-500" />
-            <span>좋아요</span>
-            <span>156</span>
+          <div className="flex items-center gap-1 text-gray-500">
+            <ThumbsUp className="size-5" />
+            <span>좋아요 156</span>
           </div>
-          <div>
-            <span>댓글</span>
-            <span>6</span>
+          <div className="flex items-center gap-1">
+            <span>댓글 6</span>
           </div>
-          <div>
-            <span>조회수</span>
-            <span>60</span>
+          <div className="flex items-center gap-1">
+            <span>조회수 60</span>
           </div>
         </div>
 
-        <div>
+        <div className="flex items-center gap-2">
           {/* 프로필 사진 / 이름 */}
-          <div>
-            <img src="" alt="" />
-            <span>조조야</span>
+          <div className="flex items-center gap-1">
+            <img
+              src=""
+              alt="조조야-profile-image"
+              className="size-6 rounded-full"
+            />
+            <span className="text-xs text-gray-600">조조야</span>
           </div>
 
           {/* 작성 시기 */}
-          <span>1시간 전</span>
+          <span className="text-xs text-gray-400">1시간 전</span>
         </div>
       </div>
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -9,6 +9,7 @@
   --color-primary-400: #7c35d9;
   --color-primary-200: #d0b3f6;
   --color-primary-100: #efe6fc;
+  --color-primary-50: #f7f2ff;
 
   /* Gray Colors */
   --color-gray-primary: #121212;

--- a/src/mocks/data/postCardData.ts
+++ b/src/mocks/data/postCardData.ts
@@ -11,7 +11,7 @@ export const postCardData = {
   commentCount: 6,
   viewCount: 60,
   likeCount: 156,
-  createdAt: '2025-10-30T14:01:57.505250+09:00',
-  updatedAt: '2025-10-30T14:01:57.505250+09:00',
+  createdAt: '2026-03-12T14:01:57.505250+09:00',
+  updatedAt: '2026-03-12T14:01:57.505250+09:00',
   categoryName: '구인/협업',
 }

--- a/src/mocks/data/postCardData.ts
+++ b/src/mocks/data/postCardData.ts
@@ -1,0 +1,17 @@
+export const postCardData = {
+  id: 1,
+  author: {
+    id: 1,
+    nickname: '조조야',
+    profileImgUrl: 'https://picsum.photos/200/300',
+  },
+  title: '데이터 분석 프로젝트 구합니다!',
+  thumbnailImgUrl: 'https://picsum.photos/600/400',
+  contentPreview: '저는 완전 기초인데 혹시 같이 프로젝트 만드실분 계신가요?!',
+  commentCount: 6,
+  viewCount: 60,
+  likeCount: 156,
+  createdAt: '2025-10-30T14:01:57.505250+09:00',
+  updatedAt: '2025-10-30T14:01:57.505250+09:00',
+  categoryName: '구인/협업',
+}

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,19 @@
+export function formatCreatedTime(date: string) {
+  const dateValue = new Date(date)
+  const createdTime = dateValue.getTime()
+  const currentTime = Date.now()
+  const dateDifference = currentTime - createdTime
+
+  const minute = 60 * 1000
+  const hour = 60 * minute
+  const day = 24 * hour
+
+  if (dateDifference < minute) return '방금 전'
+  if (dateDifference < hour)
+    return `${Math.floor(dateDifference / minute)}분 전`
+  if (dateDifference < day) return `${Math.floor(dateDifference / hour)}시간 전`
+  if (dateDifference < 7 * day)
+    return `${Math.floor(dateDifference / day)}일 전`
+
+  return `${dateValue.getFullYear()}년 ${dateValue.getMonth() + 1}월 ${dateValue.getDate()}일`
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #34

## ✨ 변경 내용
<!-- 변경한 내용을 간략하게 설명해주세요. -->
- 피그마 디자인 참고하여 게시글 카드 컴포넌트 구조 및 스타일링 지정
- [Lorem Picsum](https://picsum.photos/) 활용하여 프로필 사진, 게시글 이미지에 랜덤 이미지 렌더링
- 게시글 카드 props 지정

  - `category`, `title`, `contentPreview`, `likeCount`, `viewCount`, `commentCount`, `authorName`, `authorProfileImg`, `createdAt` 
- 게시글 카드 더미데이터 추가 및 적용

  - api 명세서 참고 (50번 api)

## 📸 스크린샷(선택)
<!-- 스크린샷이 있다면 첨부해주세요. -->
- 게시글 카드 렌더링 (더미 데이터 적용)
<img width="1421" height="671" alt="image" src="https://github.com/user-attachments/assets/7df3b10c-2eed-4012-8efa-4bad49fd68ff" />

- 게시글 카드 `hover` 상태
<img width="1420" height="670" alt="image" src="https://github.com/user-attachments/assets/b7cf9bee-706b-4f67-92cc-273d3c361336" />



## 📚 참고사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- **index.css** 컬러 토큰에 `--color-primary-50` 추가했습니다! (게시글 카드 hover용)
- 게시글 목록 조회 api 요청 시 `카테고리 id`가 아닌 `이름`을 받아오도록 백엔드 측에 요청드렸습니다.