### PR TITLE
[Feat] 공통 Modal 컴포넌트 추가 및 디자인 적용

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <div id="modal-root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,21 +1,40 @@
 import type { ReactNode } from 'react'
 import { createPortal } from 'react-dom'
+import { cva } from 'class-variance-authority'
 import { cn } from '../lib/utils'
+import { Button } from './Button'
+
+const modalVariants = cva(
+  'bg-surface-default flex flex-col justify-between rounded-xl',
+  {
+    variants: {
+      variant: {
+        delete: 'h-[195px] w-107 p-7 shadow-[var(--shadow-modal-delete)]',
+        alert: 'h-[173px] w-107 p-7 shadow-[var(--shadow-modal)]',
+      },
+    },
+    defaultVariants: {
+      variant: 'delete',
+    },
+  }
+)
 
 interface ModalProps {
   isOpen: boolean
   onClose: () => void
-  message: string | ReactNode
-  children: ReactNode
+  onConfirm?: () => void
+  message: ReactNode
   variant?: 'delete' | 'alert'
+  confirmText?: string
 }
 
 export const Modal = ({
   isOpen,
   onClose,
+  onConfirm,
   message,
-  children,
   variant = 'delete',
+  confirmText = '확인',
 }: ModalProps) => {
   if (!isOpen) return null
 
@@ -29,26 +48,38 @@ export const Modal = ({
     >
       <div
         onClick={(e) => e.stopPropagation()}
-        className={cn(
-          'bg-surface-default flex flex-col justify-between rounded-xl',
-          variant === 'delete' &&
-            'h-[165px] w-[428px] p-[24px] shadow-[0px_4px_16px_0px_#00000040]',
-          variant === 'alert' &&
-            'h-[173px] w-[428px] p-[28px] shadow-[0px_0px_16px_0px_#A0A0A040]'
-        )}
+        className={cn(modalVariants({ variant }))}
       >
-        <div className="text-text-main mt-2 text-base leading-[1.4] font-normal tracking-[-0.03em]">
+        <div className="text-text-main text-base leading-[1.4] font-normal tracking-[-0.03em]">
           {message}
         </div>
-
         {/* 하단 버튼 영역 */}
         <div
           className={cn(
             'flex',
-            variant === 'delete' ? 'justify-end gap-2' : 'justify-end'
+            'flex justify-end',
+            variant === 'delete' && 'gap-2'
           )}
         >
-          {children}
+          {variant === 'delete' && (
+            <Button
+              variant="ghost"
+              onClick={onClose}
+              className="bg-primary-100 text-primary-default hover:bg-primary-200 h-auto rounded-full px-6 py-2.5"
+            >
+              취소
+            </Button>
+          )}
+          <Button
+            variant="fill"
+            onClick={onConfirm}
+            className={cn(
+              'h-auto rounded-full py-2.5',
+              variant === 'delete' ? 'px-6' : 'px-8'
+            )}
+          >
+            {confirmText}
+          </Button>
         </div>
       </div>
     </div>,

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from 'react'
+import { createPortal } from 'react-dom'
+import { cn } from '../lib/utils'
+
+interface ModalProps {
+  isOpen: boolean
+  onClose: () => void
+  message: string | ReactNode
+  children: ReactNode
+  variant?: 'delete' | 'alert'
+}
+
+export const Modal = ({
+  isOpen,
+  onClose,
+  message,
+  children,
+  variant = 'delete',
+}: ModalProps) => {
+  if (!isOpen) return null
+
+  const modalRoot = document.getElementById('modal-root')
+  if (!modalRoot) return null
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={onClose}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className={cn(
+          'bg-surface-default flex flex-col justify-between rounded-xl',
+          variant === 'delete' &&
+            'h-[165px] w-[428px] p-[24px] shadow-[0px_4px_16px_0px_#00000040]',
+          variant === 'alert' &&
+            'h-[173px] w-[428px] p-[28px] shadow-[0px_0px_16px_0px_#A0A0A040]'
+        )}
+      >
+        <div className="text-text-main mt-2 text-base leading-[1.4] font-normal tracking-[-0.03em]">
+          {message}
+        </div>
+
+        {/* 하단 버튼 영역 */}
+        <div
+          className={cn(
+            'flex',
+            variant === 'delete' ? 'justify-end gap-2' : 'justify-end'
+          )}
+        >
+          {children}
+        </div>
+      </div>
+    </div>,
+    modalRoot
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -42,6 +42,7 @@
   /* Custom Box Shadow */
   --shadow-box: 0 4px 4px #00000025;
   --shadow-modal: 0 0 16px #a0a0a025;
+  --shadow-modal-delete: 0 4px 16px #00000040;
   --shadow-toast: 4px 4px 4px #83838325;
 
   /* ---------- Custom Sizes ---------- */


### PR DESCRIPTION
## 📌 관련 이슈
closed #38 
## ✨ 변경 내용
게시글 삭제 확인 팝업, 질문 내용 공백시 팝업 컴포넌트 구현
## 📸 스크린샷(선택)
<img width="624" height="586" alt="스크린샷 2026-03-12 오후 10 05 31" src="https://github.com/user-attachments/assets/5ae9ca0a-1fdb-4304-bbfa-42e0e4fb1d53" />
<img width="582" height="552" alt="스크린샷 2026-03-12 오후 10 05 36" src="https://github.com/user-attachments/assets/85e73e46-08aa-4a9d-b8ed-44282dec5bf6" />



## 📚 참고사항
처음 커밋할때 이슈번호를 잘못 적어서 한참 삽질하다가 첫 커밋의 이슈번호를 #38로 수정했습니다. 그때문인지 Files changed가 제대로 못 읽어오는거 같은데 왼쪽 상단에 모든 커밋말고 리팩토리 커밋을 눌러야만 수정 코드가 보입니다....제가 썼던 test.tsx 첨부하려했는데 'h1' 이런게 들어있어서 노선 프론트엔드 1팀 페이지 3.TASK DISTRIBUTION 안 팝업 안에 첨부합니다.
