### PR TITLE
[Feat] 페이지네이션 컴포넌트 구현

### DIFF
--- a/src/assets/images/Right.svg
+++ b/src/assets/images/Right.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7 16L13 10L7 4" stroke="#4D4D4D" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/src/assets/images/double-left.svg
+++ b/src/assets/images/double-left.svg
@@ -1,0 +1,4 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M15 16L9 10L15 4" stroke="#4D4D4D" stroke-width="1.5" stroke-linecap="round"/>
+<path d="M11 16L5 10L11 4" stroke="#4D4D4D" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/src/assets/images/double-right.svg
+++ b/src/assets/images/double-right.svg
@@ -1,0 +1,4 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5 16L11 10L5 4" stroke="#4D4D4D" stroke-width="1.5" stroke-linecap="round"/>
+<path d="M9 16L15 10L9 4" stroke="#4D4D4D" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/src/assets/images/left.svg
+++ b/src/assets/images/left.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M13 16L7 10L13 4" stroke="#4D4D4D" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { usePagination } from '../hooks/usePagination'
 import DoubleLeftIcon from '../assets/images/double-left.svg?react'
 import LeftIcon from '../assets/images/left.svg?react'
 import RightIcon from '../assets/images/right.svg?react'
@@ -15,50 +15,14 @@ export const Pagination = ({
   totalPages,
   onPageChange,
 }: PaginationProps) => {
-  const [maxVisiblePages, setMaxVisiblePages] = useState(10)
-  const containerRef = useRef<HTMLElement>(null)
-
-  useEffect(() => {
-    const observer = new ResizeObserver((entries) => {
-      for (const entry of entries) {
-        const containerWidth = entry.contentRect.width
-
-        // 화살표 4개(160px) 공간 확보
-        const availableWidth = containerWidth - 160
-
-        // 남은 공간을 숫자 버튼 너비(40px)로 나눔
-        const calculatedPages = Math.floor(availableWidth / 40)
-
-        // 최대 10개 고정 공간이 모자랄 때만 최소 5개까지 자연스럽게 축소
-        const responsivePages = Math.max(5, Math.min(10, calculatedPages))
-
-        setMaxVisiblePages(responsivePages)
-      }
-    })
-
-    if (containerRef.current) {
-      observer.observe(containerRef.current)
-    }
-
-    return () => observer.disconnect()
-  }, [])
-
-  const currentBlock = Math.ceil(currentPage / maxVisiblePages)
-  const startPage = (currentBlock - 1) * maxVisiblePages + 1
-  const endPage = Math.min(startPage + maxVisiblePages - 1, totalPages)
-
-  const pages = Array.from(
-    { length: endPage - startPage + 1 },
-    (_, i) => startPage + i
+  const { containerRef, pages, isFirstPage, isLastPage } = usePagination(
+    currentPage,
+    totalPages
   )
-
-  const isFirstPage = currentPage === 1
-  const isLastPage = currentPage === totalPages
-
   return (
     <nav
       ref={containerRef}
-      className="mx-auto flex h-8 w-full max-w-[600px] items-center justify-center gap-2 overflow-hidden"
+      className="mx-auto flex h-8 w-full max-w-150 items-center justify-center gap-2 overflow-hidden"
     >
       <button
         onClick={() => onPageChange(1)}

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,0 +1,116 @@
+import { useState, useEffect, useRef } from 'react'
+import DoubleLeftIcon from '../assets/images/double-left.svg?react'
+import LeftIcon from '../assets/images/left.svg?react'
+import RightIcon from '../assets/images/right.svg?react'
+import DoubleRightIcon from '../assets/images/double-right.svg?react'
+
+interface PaginationProps {
+  currentPage: number
+  totalPages: number
+  onPageChange: (page: number) => void
+}
+
+export const Pagination = ({
+  currentPage,
+  totalPages,
+  onPageChange,
+}: PaginationProps) => {
+  const [maxVisiblePages, setMaxVisiblePages] = useState(10)
+  const containerRef = useRef<HTMLElement>(null)
+
+  useEffect(() => {
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const containerWidth = entry.contentRect.width
+
+        // 화살표 4개(160px) 공간 확보
+        const availableWidth = containerWidth - 160
+
+        // 남은 공간을 숫자 버튼 너비(40px)로 나눔
+        const calculatedPages = Math.floor(availableWidth / 40)
+
+        // 최대 10개 고정 공간이 모자랄 때만 최소 5개까지 자연스럽게 축소
+        const responsivePages = Math.max(5, Math.min(10, calculatedPages))
+
+        setMaxVisiblePages(responsivePages)
+      }
+    })
+
+    if (containerRef.current) {
+      observer.observe(containerRef.current)
+    }
+
+    return () => observer.disconnect()
+  }, [])
+
+  const currentBlock = Math.ceil(currentPage / maxVisiblePages)
+  const startPage = (currentBlock - 1) * maxVisiblePages + 1
+  const endPage = Math.min(startPage + maxVisiblePages - 1, totalPages)
+
+  const pages = Array.from(
+    { length: endPage - startPage + 1 },
+    (_, i) => startPage + i
+  )
+
+  const isFirstPage = currentPage === 1
+  const isLastPage = currentPage === totalPages
+
+  return (
+    <nav
+      ref={containerRef}
+      className="mx-auto flex h-8 w-full max-w-[600px] items-center justify-center gap-2 overflow-hidden"
+    >
+      <button
+        onClick={() => onPageChange(1)}
+        disabled={isFirstPage}
+        className="text-text-light hover:text-text-sub flex h-8 w-8 shrink-0 items-center justify-center transition-colors disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        <DoubleLeftIcon />
+      </button>
+
+      <button
+        onClick={() => onPageChange(currentPage - 1)}
+        disabled={isFirstPage}
+        className="text-text-light hover:text-text-sub flex h-8 w-8 shrink-0 items-center justify-center transition-colors disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        <LeftIcon />
+      </button>
+
+      <div className="flex gap-2">
+        {pages.map((page) => {
+          const isSelected = currentPage === page
+
+          return (
+            <button
+              key={page}
+              onClick={() => onPageChange(page)}
+              className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg p-2.5 text-sm font-medium transition-colors ${
+                isSelected
+                  ? 'bg-primary-default text-surface-default'
+                  : 'bg-surface-default text-text-sub hover:bg-primary-100 hover:text-primary-default active:bg-primary-200 active:text-primary-default'
+              } `}
+            >
+              {page}
+            </button>
+          )
+        })}
+      </div>
+
+      <button
+        onClick={() => onPageChange(currentPage + 1)}
+        disabled={isLastPage}
+        className="text-text-light hover:text-text-sub flex h-8 w-8 shrink-0 items-center justify-center transition-colors disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        <RightIcon />
+      </button>
+
+      <button
+        onClick={() => onPageChange(totalPages)}
+        disabled={isLastPage}
+        className="text-text-light hover:text-text-sub flex h-8 w-8 shrink-0 items-center justify-center transition-colors disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        <DoubleRightIcon />
+      </button>
+    </nav>
+  )
+}

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -1,0 +1,52 @@
+import { useState, useEffect, useRef } from 'react'
+
+export const usePagination = (currentPage: number, totalPages: number) => {
+  const [maxVisiblePages, setMaxVisiblePages] = useState(10)
+  const containerRef = useRef<HTMLElement>(null)
+
+  useEffect(() => {
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const containerWidth = entry.contentRect.width
+
+        // 화살표 4개(160px) 공간 확보
+        const availableWidth = containerWidth - 160
+
+        // 남은 공간을 숫자 버튼 너비(40px)로 나눔
+        const calculatedPages = Math.floor(availableWidth / 40)
+
+        // 최대 10개 고정 공간이 모자랄 때만 최소 5개까지 자연스럽게 축소
+        const responsivePages = Math.max(5, Math.min(10, calculatedPages))
+
+        setMaxVisiblePages(responsivePages)
+      }
+    })
+
+    if (containerRef.current) {
+      observer.observe(containerRef.current)
+    }
+
+    return () => observer.disconnect()
+  }, [])
+
+  // 페이지 블록 계산
+  const currentBlock = Math.ceil(currentPage / maxVisiblePages)
+  const startPage = (currentBlock - 1) * maxVisiblePages + 1
+  const endPage = Math.min(startPage + maxVisiblePages - 1, totalPages)
+
+  const pages = Array.from(
+    { length: endPage - startPage + 1 },
+    (_, i) => startPage + i
+  )
+
+  const isFirstPage = currentPage === 1
+  const isLastPage = currentPage === totalPages
+
+  // 컴포넌트에서 쓸 수 있게 반환
+  return {
+    containerRef,
+    pages,
+    isFirstPage,
+    isLastPage,
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈
closed #41 

## ✨ 변경 내용
페이지네이션 컴포넌트구현 
반응형 레이아웃 고려해서 width에 따라 페이지네이션 총 개수 달라지게 설정
refactor: Pagination 커스텀 훅(usePagination) 분리 

## 📸 스크린샷(선택)
<img width="1004" height="615" alt="스크린샷 2026-03-14 오후 5 52 57" src="https://github.com/user-attachments/assets/882ce754-5716-4db2-8aa9-7cc6f958ab35" />
<img width="501" height="388" alt="스크린샷 2026-03-14 오후 5 16 44" src="https://github.com/user-attachments/assets/cf132da7-a951-4b36-88fe-fc0e2bbf93f5" />
<img width="596" height="358" alt="스크린샷 2026-03-14 오후 5 17 32" src="https://github.com/user-attachments/assets/7b2e75da-4ddd-4988-a397-45a2a7fd23c7" />
<img width="751" height="511" alt="스크린샷 2026-03-14 오후 5 18 02" src="https://github.com/user-attachments/assets/a19eb9c4-d47c-4492-bd5f-bb45580d46b4" />

## 📚 참고사항
노션 TASK DISTRIBUTION에 테스트 코드 첨부했습니다! 