### PR TITLE
[Feat] 게시글 수정 페이지 구현

### DIFF
--- a/src/api/postAPI.ts
+++ b/src/api/postAPI.ts
@@ -3,6 +3,7 @@ import type {
   CreatePostRequest,
   CreatePostResponse,
   GetPostCategoriesResponse,
+  UpdatePostRequest,
 } from '../types'
 
 // 카테고리 목록 조회
@@ -25,14 +26,7 @@ async function getPostDetailAPI(postId: string) {
 }
 
 // 게시글 수정
-async function updatePostAPI(
-  postId: string,
-  params: {
-    title: string
-    content: string
-    category_id: number
-  }
-) {
+async function updatePostAPI(postId: string, params: UpdatePostRequest) {
   const response = await instance.put(`/posts/${postId}`, params)
   return response.data
 }

--- a/src/api/postAPI.ts
+++ b/src/api/postAPI.ts
@@ -5,15 +5,36 @@ import type {
   GetPostCategoriesResponse,
 } from '../types'
 
+// 카테고리 목록 조회
 async function getPostCategoriesAPI() {
   const response =
     await instance.get<GetPostCategoriesResponse>('/posts/categories')
   return response.data
 }
 
+// 게시글 생성
 async function createPostAPI(params: CreatePostRequest) {
   const response = await instance.post<CreatePostResponse>('/posts', params)
   return response.data
 }
 
-export { getPostCategoriesAPI, createPostAPI }
+// 게시글 상세 조회
+async function getPostDetailAPI(postId: string) {
+  const response = await instance.get(`/posts/${postId}`)
+  return response.data
+}
+
+// 게시글 수정
+async function updatePostAPI(
+  postId: string,
+  params: {
+    title: string
+    content: string
+    category_id: number
+  }
+) {
+  const response = await instance.put(`/posts/${postId}`, params)
+  return response.data
+}
+
+export { getPostCategoriesAPI, createPostAPI, getPostDetailAPI, updatePostAPI }

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -1,35 +1,29 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { ChevronDown } from 'lucide-react'
 import { cn } from '../lib/utils'
 
 interface DropdownProps {
-  options?: string[]
+  options: string[]
   placeholder?: string
   onSelect?: (value: string) => void
+  selected?: string
 }
 
 export default function Dropdown({
-  options = [
-    'Select 01',
-    'Select 02',
-    'Select 03',
-    'Select 04',
-    '기타(직접입력)',
-  ],
+  options,
   placeholder = '해당되는 항목을 선택해 주세요.',
   onSelect,
+  selected: selectedProp,
 }: DropdownProps) {
   const [isOpen, setIsOpen] = useState(false)
-  const [selected, setSelected] = useState(placeholder)
-  const [customText, setCustomText] = useState('')
+  const [selected, setSelected] = useState(selectedProp ?? placeholder)
 
-  const isCustomSelected = selected === '기타(직접입력)'
-  const currentOptionNum = options.length
+  useEffect(() => {
+    setSelected(selectedProp ?? placeholder)
+  }, [selectedProp, placeholder])
 
   return (
-    /* 최상단 컨테이너 */
     <div className="relative flex w-full flex-col gap-0">
-      {/* 상단 버튼 */}
       <button
         type="button"
         onClick={() => setIsOpen((prev) => !prev)}
@@ -47,27 +41,16 @@ export default function Dropdown({
         />
       </button>
 
-      {/* 하단 리스트/입력창 컨테이너 */}
       {isOpen && (
-        <div
-          className={cn(
-            'shadow-box bg-surface-default absolute top-11 z-50 flex w-full flex-col rounded border border-gray-500 py-1',
-            isCustomSelected
-              ? 'h-auto'
-              : currentOptionNum <= 5
-                ? 'h-fit'
-                : 'max-h-64'
-          )}
-        >
-          {/* 옵션 리스트 */}
+        <div className="shadow-box bg-surface-default absolute top-11 z-50 flex w-full flex-col rounded border border-gray-500 py-1">
           <ul className="scrollbar scrollbar-w-2 scrollbar-thumb-gray-disabled scrollbar-track-transparent scrollbar-thumb-rounded-sm flex max-h-60 flex-col gap-2.5 overflow-y-auto p-1">
             {options.map((option) => (
               <li
                 key={option}
                 onClick={() => {
                   setSelected(option)
-                  if (onSelect) onSelect(option)
-                  if (option !== '기타(직접입력)') setIsOpen(false)
+                  onSelect?.(option)
+                  setIsOpen(false)
                 }}
                 className={cn(
                   'hover:bg-primary-100 flex h-12 w-full shrink-0 cursor-pointer items-center justify-between rounded-sm px-4 py-2.5 text-sm transition-colors',
@@ -77,7 +60,6 @@ export default function Dropdown({
                 )}
               >
                 {option}
-                {/* 체크 아이콘 */}
                 {selected === option && (
                   <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
                     <path
@@ -92,33 +74,6 @@ export default function Dropdown({
               </li>
             ))}
           </ul>
-
-          {/* 기타 직접입력 박스 */}
-          {isCustomSelected && (
-            <div className="mt-1 flex w-full flex-col border-t border-gray-100 px-1 pb-1">
-              <div className="bg-surface-sub mt-1 flex flex-col gap-1 rounded p-2">
-                {/* 입력창 타이틀 */}
-                <div className="text-text-main flex h-8 items-center px-2 text-sm font-semibold">
-                  기타(직접입력)
-                </div>
-                {/* 텍스트 입력 */}
-                <div className="bg-surface-default border-gray-250 flex flex-col rounded border px-3 py-2">
-                  <textarea
-                    value={customText}
-                    onChange={(e) =>
-                      setCustomText(e.target.value.slice(0, 100))
-                    }
-                    placeholder="탈퇴 사유를 입력해주세요."
-                    className="placeholder:text-text-disabled text-text-main h-20 w-full resize-none bg-transparent text-sm outline-none"
-                  />
-                  {/* 글자수 카운트 */}
-                  <span className="text-text-disabled mt-1 text-right text-xs">
-                    {customText.length}/100
-                  </span>
-                </div>
-              </div>
-            </div>
-          )}
         </div>
       )}
     </div>

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -43,7 +43,7 @@ export default function Dropdown({
 
       {isOpen && (
         <div className="shadow-box bg-surface-default absolute top-11 z-50 flex w-full flex-col rounded border border-gray-500 py-1">
-          <ul className="scrollbar scrollbar-w-2 scrollbar-thumb-gray-disabled scrollbar-track-transparent scrollbar-thumb-rounded-sm flex max-h-60 flex-col gap-2.5 overflow-y-auto p-1">
+          <ul className="scrollbar scrollbar-w-2 scrollbar-thumb-gray-disabled scrollbar-track-transparent scrollbar-thumb-rounded-sm flex max-h-60 flex-col gap-2 overflow-y-auto p-1">
             {options.map((option) => (
               <li
                 key={option}
@@ -53,7 +53,7 @@ export default function Dropdown({
                   setIsOpen(false)
                 }}
                 className={cn(
-                  'hover:bg-primary-100 flex h-12 w-full shrink-0 cursor-pointer items-center justify-between rounded-sm px-4 py-2.5 text-sm transition-colors',
+                  'hover:bg-primary-100 flex h-12 w-full shrink-0 cursor-pointer items-center justify-between rounded-sm px-4 py-2 text-sm transition-colors',
                   selected === option
                     ? 'text-primary-default font-semibold'
                     : 'text-text-main'

--- a/src/components/editor/EditorHeader.tsx
+++ b/src/components/editor/EditorHeader.tsx
@@ -1,9 +1,11 @@
 import Dropdown from '../Dropdown'
 
 interface EditorHeaderProps {
+  headerTitle?: string
   title: string
   onChangeTitle: (value: string) => void
   onChangeCategoryId: (value: number) => void
+  selectedCategoryId?: number | null
   categories: {
     id: number
     name: string
@@ -11,9 +13,11 @@ interface EditorHeaderProps {
 }
 
 export default function EditorHeader({
+  headerTitle = '커뮤니티 게시글 작성',
   title,
   onChangeTitle,
   onChangeCategoryId,
+  selectedCategoryId,
   categories,
 }: EditorHeaderProps) {
   return (
@@ -22,7 +26,7 @@ export default function EditorHeader({
       {/* 제목 */}
       <div className="mb-4 flex items-center">
         <h1 className="text-gray-primary text-8 leading-11 font-bold tracking-tighter">
-          커뮤니티 게시글 작성
+          {headerTitle}
         </h1>
       </div>
 
@@ -37,6 +41,9 @@ export default function EditorHeader({
             <Dropdown
               placeholder="카테고리 선택"
               options={categories.map((c) => c.name)}
+              selected={
+                categories.find((c) => c.id === selectedCategoryId)?.name
+              }
               onSelect={(value) => {
                 const selected = categories.find((c) => c.name === value)
                 if (selected) {

--- a/src/hooks/queries/usePostQueries.ts
+++ b/src/hooks/queries/usePostQueries.ts
@@ -10,6 +10,7 @@ import type {
   CreatePostRequest,
   CreatePostResponse,
   GetPostCategoriesResponse,
+  UpdatePostRequest,
 } from '../../types'
 
 // 카테고리 목록 조회
@@ -60,11 +61,7 @@ function useUpdatePost() {
       params,
     }: {
       postId: string
-      params: {
-        title: string
-        content: string
-        category_id: number
-      }
+      params: UpdatePostRequest
     }) => updatePostAPI(postId, params),
 
     onSuccess: () => {

--- a/src/hooks/queries/usePostQueries.ts
+++ b/src/hooks/queries/usePostQueries.ts
@@ -1,5 +1,10 @@
 import { useMutation, useQuery } from '@tanstack/react-query'
-import { createPostAPI, getPostCategoriesAPI } from '../../api/postAPI'
+import {
+  createPostAPI,
+  getPostCategoriesAPI,
+  getPostDetailAPI,
+  updatePostAPI,
+} from '../../api/postAPI'
 import { useToast } from '../useToast'
 import type {
   CreatePostRequest,
@@ -7,6 +12,7 @@ import type {
   GetPostCategoriesResponse,
 } from '../../types'
 
+// 카테고리 목록 조회
 function usePostCategories() {
   return useQuery<GetPostCategoriesResponse>({
     queryKey: ['postCategories'],
@@ -14,6 +20,7 @@ function usePostCategories() {
   })
 }
 
+// 게시글 생성
 function useCreatePost() {
   const { showToast } = useToast()
 
@@ -34,4 +41,44 @@ function useCreatePost() {
   })
 }
 
-export { usePostCategories, useCreatePost }
+// 게시글 상세 조회
+function usePostDetail(postId: string) {
+  return useQuery({
+    queryKey: ['postDetail', postId],
+    queryFn: () => getPostDetailAPI(postId),
+    enabled: !!postId,
+  })
+}
+
+// 게시글 수정
+function useUpdatePost() {
+  const { showToast } = useToast()
+
+  return useMutation({
+    mutationFn: ({
+      postId,
+      params,
+    }: {
+      postId: string
+      params: {
+        title: string
+        content: string
+        category_id: number
+      }
+    }) => updatePostAPI(postId, params),
+
+    onSuccess: () => {
+      showToast('success', '게시글 수정 완료', '게시글이 수정되었습니다!')
+    },
+
+    onError: () => {
+      showToast(
+        'default',
+        '게시글 수정 실패',
+        '게시글 수정 중 오류가 발생했습니다.'
+      )
+    },
+  })
+}
+
+export { usePostCategories, useCreatePost, usePostDetail, useUpdatePost }

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,11 +1,19 @@
 // handlers.ts
 import { http, HttpResponse } from 'msw'
-import { postHandlers } from './handlers/post-handlers'
+import {
+  getPostCategoriesMOCK,
+  createPostMOCK,
+  getPostDetailMOCK,
+  updatePostMOCK,
+} from './handlers/post-handlers'
 
 export const handlers = [
   http.get('/api/hello', () => {
     return HttpResponse.json({ message: 'Hello, world!', code: 200 })
   }),
 
-  ...postHandlers,
+  getPostCategoriesMOCK,
+  createPostMOCK,
+  getPostDetailMOCK,
+  updatePostMOCK,
 ]

--- a/src/mocks/handlers/post-handlers.ts
+++ b/src/mocks/handlers/post-handlers.ts
@@ -4,12 +4,21 @@ import type { CreatePostRequest, CreatePostResponse } from '../../types'
 
 let postPk = 1
 
+const mockPosts: {
+  pk: number
+  title: string
+  content: string
+  category_id: number
+}[] = []
+
+const BASE_URL = 'https://api.ozcodingschool.site/api/v1'
+
 export const postHandlers = [
-  http.get('/api/v1/posts/categories', () => {
+  http.get(`${BASE_URL}/posts/categories`, () => {
     return HttpResponse.json(categoryData, { status: 200 })
   }),
 
-  http.post('/api/v1/posts', async ({ request }) => {
+  http.post(`${BASE_URL}/posts`, async ({ request }) => {
     const body = (await request.json()) as CreatePostRequest
 
     const errors: Record<string, string[]> = {}
@@ -35,11 +44,105 @@ export const postHandlers = [
       )
     }
 
+    const newPost = {
+      pk: postPk,
+      title: body.title,
+      content: body.content,
+      category_id: body.category_id,
+    }
+
+    mockPosts.push(newPost)
+
     const response: CreatePostResponse = {
       detail: '게시글이 성공적으로 등록되었습니다.',
       pk: postPk++,
     }
 
     return HttpResponse.json(response, { status: 201 })
+  }),
+
+  http.get(`${BASE_URL}/posts/:postId`, ({ params }) => {
+    const postId = Number(params.postId)
+    const post = mockPosts.find((item) => item.pk === postId)
+
+    if (!post) {
+      return HttpResponse.json(
+        {
+          error_detail: '게시글을 찾을 수 없습니다.',
+        },
+        { status: 404 }
+      )
+    }
+
+    const category = categoryData.find((item) => item.id === post.category_id)
+
+    return HttpResponse.json(
+      {
+        id: post.pk,
+        title: post.title,
+        content: post.content,
+        category: {
+          id: category?.id ?? post.category_id,
+          name: category?.name ?? '',
+        },
+      },
+      { status: 200 }
+    )
+  }),
+
+  http.put(`${BASE_URL}/posts/:postId`, async ({ params, request }) => {
+    const postId = Number(params.postId)
+    const body = (await request.json()) as CreatePostRequest
+
+    const postIndex = mockPosts.findIndex((item) => item.pk === postId)
+
+    if (postIndex === -1) {
+      return HttpResponse.json(
+        {
+          error_detail: '해당 게시글을 찾을 수 없습니다.',
+        },
+        { status: 404 }
+      )
+    }
+
+    const errors: Record<string, string[]> = {}
+
+    if (!body.title) {
+      errors.title = ['이 필드는 필수 항목입니다.']
+    }
+
+    if (!body.content) {
+      errors.content = ['이 필드는 필수 항목입니다.']
+    }
+
+    if (!body.category_id) {
+      errors.category_id = ['이 필드는 필수 항목입니다.']
+    }
+
+    if (Object.keys(errors).length > 0) {
+      return HttpResponse.json(
+        {
+          error_detail: errors,
+        },
+        { status: 400 }
+      )
+    }
+
+    mockPosts[postIndex] = {
+      pk: postId,
+      title: body.title,
+      content: body.content,
+      category_id: body.category_id,
+    }
+
+    return HttpResponse.json(
+      {
+        id: postId,
+        title: body.title,
+        content: body.content,
+        category_id: body.category_id,
+      },
+      { status: 200 }
+    )
   }),
 ]

--- a/src/mocks/handlers/post-handlers.ts
+++ b/src/mocks/handlers/post-handlers.ts
@@ -1,19 +1,30 @@
 import { http, HttpResponse } from 'msw'
 import { categoryData } from '../data/categoryData'
+import { postCardData } from '../data/postCardData'
 import type {
   CreatePostRequest,
   CreatePostResponse,
   UpdatePostRequest,
 } from '../../types'
 
-let postPk = 1
+let postPk = 2
+
+const initialCategory =
+  categoryData.find((item) => item.name === '프로젝트 구인') ?? categoryData[0]
 
 const mockPosts: {
   pk: number
   title: string
   content: string
   category_id: number
-}[] = []
+}[] = [
+  {
+    pk: postCardData.id,
+    title: postCardData.title,
+    content: postCardData.contentPreview,
+    category_id: initialCategory.id,
+  },
+]
 
 const BASE_URL = import.meta.env.VITE_API_BASE_URL
 
@@ -89,19 +100,19 @@ const getPostDetailMOCK = http.get(
         id: post.pk,
         title: post.title,
         author: {
-          id: 1,
-          nickname: '관리자',
-          profile_img_url: '',
+          id: postCardData.author.id,
+          nickname: postCardData.author.nickname,
+          profile_img_url: postCardData.author.profileImgUrl,
         },
         content: post.content,
         category: {
           id: category?.id ?? post.category_id,
           name: category?.name ?? '',
         },
-        view_count: 0,
-        like_count: 0,
-        created_at: '2026-03-19T00:00:00',
-        updated_at: '2026-03-19T00:00:00',
+        view_count: postCardData.viewCount,
+        like_count: postCardData.likeCount,
+        created_at: postCardData.createdAt,
+        updated_at: postCardData.updatedAt,
       },
       { status: 200 }
     )

--- a/src/mocks/handlers/post-handlers.ts
+++ b/src/mocks/handlers/post-handlers.ts
@@ -1,6 +1,10 @@
 import { http, HttpResponse } from 'msw'
 import { categoryData } from '../data/categoryData'
-import type { CreatePostRequest, CreatePostResponse } from '../../types'
+import type {
+  CreatePostRequest,
+  CreatePostResponse,
+  UpdatePostRequest,
+} from '../../types'
 
 let postPk = 1
 
@@ -80,11 +84,16 @@ export const postHandlers = [
       {
         id: post.pk,
         title: post.title,
+        author: { id: 1, nickname: '관리자', profile_img_url: '' },
         content: post.content,
         category: {
           id: category?.id ?? post.category_id,
           name: category?.name ?? '',
         },
+        view_count: 0,
+        like_count: 0,
+        created_at: '2026-03-19T00:00:00',
+        updated_at: '2026-03-19T00:00:00',
       },
       { status: 200 }
     )
@@ -92,7 +101,7 @@ export const postHandlers = [
 
   http.put(`${BASE_URL}/posts/:postId`, async ({ params, request }) => {
     const postId = Number(params.postId)
-    const body = (await request.json()) as CreatePostRequest
+    const body = (await request.json()) as UpdatePostRequest
 
     const postIndex = mockPosts.findIndex((item) => item.pk === postId)
 

--- a/src/mocks/handlers/post-handlers.ts
+++ b/src/mocks/handlers/post-handlers.ts
@@ -15,57 +15,61 @@ const mockPosts: {
   category_id: number
 }[] = []
 
-const BASE_URL = 'https://api.ozcodingschool.site/api/v1'
+const BASE_URL = import.meta.env.VITE_API_BASE_URL
 
-export const postHandlers = [
-  http.get(`${BASE_URL}/posts/categories`, () => {
-    return HttpResponse.json(categoryData, { status: 200 })
-  }),
+// 카테고리 목록
+const getPostCategoriesMOCK = http.get(`${BASE_URL}/posts/categories`, () => {
+  return HttpResponse.json(categoryData, { status: 200 })
+})
 
-  http.post(`${BASE_URL}/posts`, async ({ request }) => {
-    const body = (await request.json()) as CreatePostRequest
+// 게시글 생성
+const createPostMOCK = http.post(`${BASE_URL}/posts`, async ({ request }) => {
+  const body = (await request.json()) as CreatePostRequest
 
-    const errors: Record<string, string[]> = {}
+  const errors: Record<string, string[]> = {}
 
-    if (!body.title) {
-      errors.title = ['이 필드는 필수 항목입니다.']
-    }
+  if (!body.title) {
+    errors.title = ['이 필드는 필수 항목입니다.']
+  }
 
-    if (!body.content) {
-      errors.content = ['이 필드는 필수 항목입니다.']
-    }
+  if (!body.content) {
+    errors.content = ['이 필드는 필수 항목입니다.']
+  }
 
-    if (!body.category_id) {
-      errors.category_id = ['이 필드는 필수 항목입니다.']
-    }
+  if (!body.category_id) {
+    errors.category_id = ['이 필드는 필수 항목입니다.']
+  }
 
-    if (Object.keys(errors).length > 0) {
-      return HttpResponse.json(
-        {
-          error_detail: errors,
-        },
-        { status: 400 }
-      )
-    }
+  if (Object.keys(errors).length > 0) {
+    return HttpResponse.json(
+      {
+        error_detail: errors,
+      },
+      { status: 400 }
+    )
+  }
 
-    const newPost = {
-      pk: postPk,
-      title: body.title,
-      content: body.content,
-      category_id: body.category_id,
-    }
+  const newPost = {
+    pk: postPk,
+    title: body.title,
+    content: body.content,
+    category_id: body.category_id,
+  }
 
-    mockPosts.push(newPost)
+  mockPosts.push(newPost)
 
-    const response: CreatePostResponse = {
-      detail: '게시글이 성공적으로 등록되었습니다.',
-      pk: postPk++,
-    }
+  const response: CreatePostResponse = {
+    detail: '게시글이 성공적으로 등록되었습니다.',
+    pk: postPk++,
+  }
 
-    return HttpResponse.json(response, { status: 201 })
-  }),
+  return HttpResponse.json(response, { status: 201 })
+})
 
-  http.get(`${BASE_URL}/posts/:postId`, ({ params }) => {
+// 게시글 상세 조회
+const getPostDetailMOCK = http.get(
+  `${BASE_URL}/posts/:postId`,
+  ({ params }) => {
     const postId = Number(params.postId)
     const post = mockPosts.find((item) => item.pk === postId)
 
@@ -84,7 +88,11 @@ export const postHandlers = [
       {
         id: post.pk,
         title: post.title,
-        author: { id: 1, nickname: '관리자', profile_img_url: '' },
+        author: {
+          id: 1,
+          nickname: '관리자',
+          profile_img_url: '',
+        },
         content: post.content,
         category: {
           id: category?.id ?? post.category_id,
@@ -97,9 +105,12 @@ export const postHandlers = [
       },
       { status: 200 }
     )
-  }),
-
-  http.put(`${BASE_URL}/posts/:postId`, async ({ params, request }) => {
+  }
+)
+// 게시글 수정
+const updatePostMOCK = http.put(
+  `${BASE_URL}/posts/:postId`,
+  async ({ params, request }) => {
     const postId = Number(params.postId)
     const body = (await request.json()) as UpdatePostRequest
 
@@ -153,5 +164,12 @@ export const postHandlers = [
       },
       { status: 200 }
     )
-  }),
-]
+  }
+)
+
+export {
+  getPostCategoriesMOCK,
+  createPostMOCK,
+  getPostDetailMOCK,
+  updatePostMOCK,
+}

--- a/src/pages/PostCreate.tsx
+++ b/src/pages/PostCreate.tsx
@@ -8,26 +8,39 @@ import type { CreatePostRequest } from '../types'
 
 const initialContent = ''
 
+const fallbackCategories = [
+  { id: 1, name: '공지사항' },
+  { id: 2, name: '자유게시판' },
+  { id: 3, name: '질의응답' },
+]
+
 function PostCreate() {
   const [title, setTitle] = useState('')
   const [content, setContent] = useState(initialContent)
-  const [categoryId, setCategoryId] = useState<number | null>(null)
+  const [categoryId, setCategoryId] = useState<number | null>(
+    fallbackCategories[0].id // 기본 카테고리 선택
+  )
 
   const navigate = useNavigate()
 
-  const { data: categories = [] } = usePostCategories()
+  const { data } = usePostCategories()
+  const categories = data?.length ? data : fallbackCategories
+
   const { mutate: createPost } = useCreatePost()
 
   const handleSubmit = () => {
+    if (!categoryId) return
+
     const requestBody: CreatePostRequest = {
       title,
       content,
-      category_id: categoryId as number,
+      category_id: categoryId,
     }
 
     createPost(requestBody, {
-      onSuccess: () => {
-        navigate('/posts')
+      onSuccess: (res) => {
+        // 작성 완료 후 수정 페이지로 이동 (임시)
+        navigate(`/posts/edit/${res.pk}`)
       },
     })
   }
@@ -36,10 +49,12 @@ function PostCreate() {
     <div className="bg-surface-default flex w-full justify-center pt-27 pb-38">
       <div className="flex w-236 flex-col gap-13">
         <EditorHeader
+          headerTitle="커뮤니티 게시글 작성"
           title={title}
           onChangeTitle={setTitle}
           onChangeCategoryId={setCategoryId}
           categories={categories}
+          selectedCategoryId={categoryId}
         />
 
         <MarkdownEditor value={content} setValue={setContent} />

--- a/src/pages/PostCreate.tsx
+++ b/src/pages/PostCreate.tsx
@@ -5,26 +5,21 @@ import MarkdownEditor from '../components/editor/MarkdownEditor/MarkdownEditor'
 import { Button } from '../components/Button'
 import { useCreatePost, usePostCategories } from '../hooks'
 import type { CreatePostRequest } from '../types'
+import { categoryData } from '../mocks/data/categoryData'
 
 const initialContent = ''
-
-const fallbackCategories = [
-  { id: 1, name: '공지사항' },
-  { id: 2, name: '자유게시판' },
-  { id: 3, name: '질의응답' },
-]
 
 function PostCreate() {
   const [title, setTitle] = useState('')
   const [content, setContent] = useState(initialContent)
   const [categoryId, setCategoryId] = useState<number | null>(
-    fallbackCategories[0].id // 기본 카테고리 선택
+    categoryData[0].id
   )
 
   const navigate = useNavigate()
 
   const { data } = usePostCategories()
-  const categories = data?.length ? data : fallbackCategories
+  const categories = data?.length ? data : categoryData
 
   const { mutate: createPost } = useCreatePost()
 

--- a/src/pages/PostCreate.tsx
+++ b/src/pages/PostCreate.tsx
@@ -12,9 +12,7 @@ const initialContent = ''
 function PostCreate() {
   const [title, setTitle] = useState('')
   const [content, setContent] = useState(initialContent)
-  const [categoryId, setCategoryId] = useState<number | null>(
-    categoryData[0].id
-  )
+  const [categoryId, setCategoryId] = useState<number | null>(null)
 
   const navigate = useNavigate()
 

--- a/src/pages/PostCreate.tsx
+++ b/src/pages/PostCreate.tsx
@@ -47,7 +47,7 @@ function PostCreate() {
 
   return (
     <div className="bg-surface-default flex w-full justify-center pt-27 pb-38">
-      <div className="flex w-236 flex-col gap-13">
+      <div className="flex w-59 flex-col gap-4">
         <EditorHeader
           headerTitle="커뮤니티 게시글 작성"
           title={title}

--- a/src/pages/PostCreate.tsx
+++ b/src/pages/PostCreate.tsx
@@ -39,8 +39,8 @@ function PostCreate() {
   }
 
   return (
-    <div className="bg-surface-default flex w-full justify-center pt-27 pb-38">
-      <div className="flex w-59 flex-col gap-4">
+    <div className="bg-surface-default flex w-full justify-center py-20">
+      <div className="flex w-236 flex-col gap-12">
         <EditorHeader
           headerTitle="커뮤니티 게시글 작성"
           title={title}

--- a/src/pages/PostEdit.tsx
+++ b/src/pages/PostEdit.tsx
@@ -27,7 +27,7 @@ function PostEdit() {
 
   useEffect(() => {
     if (!postDetail) return
-
+    // 기존 게시글 데이터 불러오기
     setTitle(postDetail.title)
     setContent(postDetail.content)
     setCategoryId(postDetail.category?.id ?? postDetail.category_id)
@@ -47,6 +47,7 @@ function PostEdit() {
       },
       {
         onSuccess: () => {
+          // 수정 완료 후 상세 페이지로 이동 (임시)
           navigate(`/posts/${id}`)
         },
       }
@@ -55,7 +56,7 @@ function PostEdit() {
 
   return (
     <div className="bg-surface-default flex w-full justify-center pt-27 pb-38">
-      <div className="flex w-236 flex-col gap-13">
+      <div className="flex w-59 flex-col gap-4">
         <EditorHeader
           headerTitle="커뮤니티 게시글 수정"
           title={title}

--- a/src/pages/PostEdit.tsx
+++ b/src/pages/PostEdit.tsx
@@ -59,8 +59,8 @@ function PostEdit() {
   }
 
   return (
-    <div className="bg-surface-default flex w-full justify-center pt-27 pb-38">
-      <div className="flex w-59 flex-col gap-4">
+    <div className="bg-surface-default flex w-full justify-center py-20">
+      <div className="flex w-236 flex-col gap-12">
         <EditorHeader
           headerTitle="커뮤니티 게시글 수정"
           title={title}

--- a/src/pages/PostEdit.tsx
+++ b/src/pages/PostEdit.tsx
@@ -1,7 +1,78 @@
+import { useNavigate, useParams } from 'react-router'
+import { useEffect, useState } from 'react'
+import EditorHeader from '../components/editor/EditorHeader'
+import MarkdownEditor from '../components/editor/MarkdownEditor/MarkdownEditor'
+import { Button } from '../components/Button'
+import { usePostCategories, usePostDetail, useUpdatePost } from '../hooks'
+
+const fallbackCategories = [
+  { id: 1, name: '공지사항' },
+  { id: 2, name: '자유게시판' },
+  { id: 3, name: '질의응답' },
+]
+
 function PostEdit() {
+  const { id } = useParams()
+  const navigate = useNavigate()
+
+  const [title, setTitle] = useState('')
+  const [content, setContent] = useState('')
+  const [categoryId, setCategoryId] = useState<number | null>(null)
+
+  const { data } = usePostCategories()
+  const categories = data?.length ? data : fallbackCategories
+
+  const { data: postDetail } = usePostDetail(id as string)
+  const { mutate: updatePost } = useUpdatePost()
+
+  useEffect(() => {
+    if (!postDetail) return
+
+    setTitle(postDetail.title)
+    setContent(postDetail.content)
+    setCategoryId(postDetail.category?.id ?? postDetail.category_id)
+  }, [postDetail])
+
+  const handleSubmit = () => {
+    if (!categoryId) return
+
+    updatePost(
+      {
+        postId: id as string,
+        params: {
+          title,
+          content,
+          category_id: categoryId,
+        },
+      },
+      {
+        onSuccess: () => {
+          navigate(`/posts/${id}`)
+        },
+      }
+    )
+  }
+
   return (
-    <div className="h-250 w-full p-20 text-center">
-      <h1 className="text-3xl">(임시) 커뮤니티 게시글 수정 페이지 입니다!</h1>
+    <div className="bg-surface-default flex w-full justify-center pt-27 pb-38">
+      <div className="flex w-236 flex-col gap-13">
+        <EditorHeader
+          headerTitle="커뮤니티 게시글 수정"
+          title={title}
+          onChangeTitle={setTitle}
+          onChangeCategoryId={setCategoryId}
+          categories={categories}
+          selectedCategoryId={categoryId}
+        />
+
+        <MarkdownEditor value={content} setValue={setContent} />
+
+        <div className="flex w-full justify-end">
+          <Button type="submit" onClick={handleSubmit}>
+            완료
+          </Button>
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/pages/PostEdit.tsx
+++ b/src/pages/PostEdit.tsx
@@ -4,12 +4,7 @@ import EditorHeader from '../components/editor/EditorHeader'
 import MarkdownEditor from '../components/editor/MarkdownEditor/MarkdownEditor'
 import { Button } from '../components/Button'
 import { usePostCategories, usePostDetail, useUpdatePost } from '../hooks'
-
-const fallbackCategories = [
-  { id: 1, name: '공지사항' },
-  { id: 2, name: '자유게시판' },
-  { id: 3, name: '질의응답' },
-]
+import { categoryData } from '../mocks/data/categoryData'
 
 function PostEdit() {
   const { id } = useParams()
@@ -20,7 +15,7 @@ function PostEdit() {
   const [categoryId, setCategoryId] = useState<number | null>(null)
 
   const { data } = usePostCategories()
-  const categories = data?.length ? data : fallbackCategories
+  const categories = data?.length ? data : categoryData
 
   const { data: postDetail } = usePostDetail(id as string)
   const { mutate: updatePost } = useUpdatePost()

--- a/src/pages/PostEdit.tsx
+++ b/src/pages/PostEdit.tsx
@@ -40,6 +40,16 @@ function PostEdit() {
       return
     }
 
+    if (!title.trim()) {
+      showToast('default', '입력 오류', '제목을 입력해주세요.')
+      return
+    }
+
+    if (!content.trim()) {
+      showToast('default', '입력 오류', '내용을 입력해주세요.')
+      return
+    }
+
     updatePost(
       {
         postId: id as string,

--- a/src/pages/PostEdit.tsx
+++ b/src/pages/PostEdit.tsx
@@ -3,12 +3,18 @@ import { useEffect, useState } from 'react'
 import EditorHeader from '../components/editor/EditorHeader'
 import MarkdownEditor from '../components/editor/MarkdownEditor/MarkdownEditor'
 import { Button } from '../components/Button'
-import { usePostCategories, usePostDetail, useUpdatePost } from '../hooks'
+import {
+  usePostCategories,
+  usePostDetail,
+  useUpdatePost,
+  useToast,
+} from '../hooks'
 import { categoryData } from '../mocks/data/categoryData'
 
 function PostEdit() {
   const { id } = useParams()
   const navigate = useNavigate()
+  const { showToast } = useToast()
 
   const [title, setTitle] = useState('')
   const [content, setContent] = useState('')
@@ -25,11 +31,14 @@ function PostEdit() {
     // 기존 게시글 데이터 불러오기
     setTitle(postDetail.title)
     setContent(postDetail.content)
-    setCategoryId(postDetail.category?.id ?? postDetail.category_id)
+    setCategoryId(postDetail.category?.id ?? null)
   }, [postDetail])
 
   const handleSubmit = () => {
-    if (!categoryId) return
+    if (!categoryId) {
+      showToast('default', '입력 오류', '카테고리를 선택해주세요.')
+      return
+    }
 
     updatePost(
       {

--- a/src/types/api-request-types/post.ts
+++ b/src/types/api-request-types/post.ts
@@ -3,3 +3,8 @@ export interface CreatePostRequest {
   content: string
   category_id: number
 }
+export interface UpdatePostRequest {
+  title: string
+  content: string
+  category_id: number
+}


### PR DESCRIPTION
## 📌 관련 이슈
closed #59 

## ✨ 변경 내용
* 게시글 수정(Edit) 기능 구현
* 게시글 수정 API 연동
* MSW를 활용한 API mocking
* 카테고리 목록 조회 및 드롭다운 선택 기능 수정


## 📸 스크린샷(선택)
<img width="1618" height="1748" alt="image" src="https://github.com/user-attachments/assets/aeddef38-1f65-45f0-9a26-ff53d7dc9990" />
<img width="1592" height="1518" alt="image" src="https://github.com/user-attachments/assets/cbcb2a1d-f626-4ee5-a3f2-77a5e6fd636b" />


## 📚 참고사항
* 원래 페이지 흐름은 작성 → 상세/목록 → 수정으로 구성할 예정이지만
  현재 상세/목록 페이지가 미구현 또는 임시 상태라, 작성 완료 후 수정 페이지로 이동하도록 임시 구현했습니다.
  이후 상세/목록 페이지 구현되면 경로에 맞게 수정하도록 하겠습니다.
