### PR TITLE
[Feat] 액세스 토큰 관리 및 재발급 로직 추가

### DIFF
--- a/src/api/authAPI.ts
+++ b/src/api/authAPI.ts
@@ -1,0 +1,11 @@
+import type { GetAccessTokenResponse } from '../types/api-response-types/auth'
+import { instance } from './instance'
+
+async function getRefreshTokenAPI() {
+  const response = await instance.post<GetAccessTokenResponse>(
+    '/accounts/me/refresh'
+  )
+  return response.data
+}
+
+export { getRefreshTokenAPI }

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -2,4 +2,5 @@ import axios from 'axios'
 
 export const instance = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
+  withCredentials: true,
 })

--- a/src/api/interceptor.ts
+++ b/src/api/interceptor.ts
@@ -1,0 +1,55 @@
+import { useAccessTokenStore } from '../store/useAccessTokenStore'
+import { getRefreshTokenAPI } from './authAPI'
+import { instance } from './instance'
+
+instance.interceptors.request.use((config) => {
+  const { accessToken } = useAccessTokenStore()
+
+  if (accessToken) {
+    config.headers = config.headers ?? {}
+    config.headers.Authorization = `Bearer ${accessToken}`
+  }
+
+  return config
+})
+
+instance.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config
+    const { accessToken, setAccessToken, clearAccessToken } =
+      useAccessTokenStore()
+
+    // 401 에러가 아니면 그대로 에러 처리 진행
+    if (error.response?.status !== 401) {
+      return Promise.reject(error)
+    }
+
+    // 이미 한번 시도한 요청이면 종료 (무한 루프 방지)
+    if (originalRequest?._retry) {
+      clearAccessToken()
+      return Promise.reject(error)
+    }
+    originalRequest._retry = true
+
+    // 토큰 재발급 요청에서 401 에러(리프레시 토큰 만료) 발생하면 리다이렉트
+    if (originalRequest.url?.includes('accounts/me/refresh')) {
+      clearAccessToken()
+      return Promise.reject(error)
+    }
+
+    // 401 에러 발생 시 토큰 재발급 시도
+    try {
+      const { access_token: newAccessToken } = await getRefreshTokenAPI()
+      setAccessToken(newAccessToken)
+
+      originalRequest.headers = originalRequest.headers ?? {}
+      originalRequest.headers.Authorization = `Bearer ${accessToken}`
+
+      return instance(originalRequest)
+    } catch (refreshError) {
+      clearAccessToken()
+      return Promise.reject(error)
+    }
+  }
+)

--- a/src/api/interceptor.ts
+++ b/src/api/interceptor.ts
@@ -32,9 +32,10 @@ instance.interceptors.response.use(
     }
     originalRequest._retry = true
 
-    // 토큰 재발급 요청에서 401 에러(리프레시 토큰 만료) 발생하면 리다이렉트
+    // 토큰 재발급 요청에서 에러(리프레시 토큰 만료) 발생하면 리다이렉트
     if (originalRequest.url?.includes('accounts/me/refresh')) {
       clearAccessToken()
+      window.location.href = 'https://my.ozcodingschool.site/login'
       return Promise.reject(error)
     }
 

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -6,8 +6,8 @@ import {
   getPostDetailMOCK,
   updatePostMOCK,
 } from './handlers/post-handlers'
-
 import { commentHandlers } from './handlers/comment-handlers'
+import { getRefreshTokenMOCK } from './handlers/auth-handlers'
 
 export const handlers = [
   http.get('/api/hello', () => {
@@ -18,5 +18,6 @@ export const handlers = [
   createPostMOCK,
   getPostDetailMOCK,
   updatePostMOCK,
+  getRefreshTokenMOCK,
   ...commentHandlers,
 ]

--- a/src/mocks/handlers/auth-handlers.ts
+++ b/src/mocks/handlers/auth-handlers.ts
@@ -1,0 +1,36 @@
+import { http, HttpResponse } from 'msw'
+import type {
+  GetAccessTokenErrorResponse,
+  GetAccessTokenResponse,
+} from '../../types/api-response-types/auth'
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL
+
+const getRefreshTokenMOCK =
+  // JWT 토큰 재발급 API
+  http.post(`${BASE_URL}/accounts/me/refresh`, () => {
+    const successResponse: GetAccessTokenResponse = {
+      access_token: 'temporary-token-value',
+    }
+    const error400Response: GetAccessTokenErrorResponse = {
+      error_detail: {
+        refresh_token: ['이 필드는 필수 항목입니다.'],
+      },
+    }
+    const error403Response: GetAccessTokenErrorResponse = {
+      error_detail: {
+        detail: '로그인 세션이 만료되었습니다.',
+      },
+    }
+
+    /* 리프레시 토큰 보유 ver. */
+    return HttpResponse.json(successResponse, { status: 200 })
+
+    /* 리프레시 토큰 미보유 ver. */
+    // return HttpResponse.json(error400Response, { status: 400 })
+
+    /* 리프레시 토큰 만료 ver. */
+    // return HttpResponse.json(error403Response, { status: 403 })
+  })
+
+export { getRefreshTokenMOCK }

--- a/src/store/useAccessTokenStore.ts
+++ b/src/store/useAccessTokenStore.ts
@@ -1,0 +1,22 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+interface AccessTokenState {
+  accessToken: string
+  setAccessToken: (newToken: string) => void
+  clearAccessToken: () => void
+}
+
+export const useAccessTokenStore = create<AccessTokenState>()(
+  persist(
+    (set) => ({
+      // 액세스 토큰 값
+      accessToken: '',
+
+      setAccessToken: (newToken) => set({ accessToken: newToken }),
+
+      clearAccessToken: () => set({ accessToken: '' }),
+    }),
+    { name: 'tokenStorage' }
+  )
+)

--- a/src/types/api-response-types/auth.ts
+++ b/src/types/api-response-types/auth.ts
@@ -1,0 +1,12 @@
+interface GetAccessTokenResponse {
+  access_token: string
+}
+
+interface GetAccessTokenErrorResponse {
+  error_detail: {
+    refresh_token?: string[]
+    detail?: string
+  }
+}
+
+export type { GetAccessTokenResponse, GetAccessTokenErrorResponse }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #60 

## ✨ 변경 내용
<!-- 변경한 내용을 간략하게 설명해주세요. -->
- 액세스 토큰을 저장할 전역 상태 추가
  - `persist` 미들웨어를 사용해서 로컬 스토리지와 연동
  - 새로고침 시 자동으로 로컬 스토리지의 액세스 토큰 데이터를 가져와 전역 상태 값 유지
- `axios` 인스턴스 수정
- `axios` 인터셉터 추가
  - API 호출 시 액세스 토큰 값이 존재한다면 헤더에 담아 전송
  - API 응답 시 401 에러가 발생하면 토큰 재발급 로직을 한 번 실행해서 액세스 토큰 발급 시도
  - 토큰 재발급 로직에서 에러 발생 시 로그인 페이지로 리다이렉트

## 📸 스크린샷(선택)
<!-- 스크린샷이 있다면 첨부해주세요. -->

## 📚 참고사항
<!-- 참고할 사항이 있다면 적어주세요. -->
토큰 재발급 로직의 경우 **tanstack query**로 서버 상태를 관리하는 방식보다 **axios**와 `try`, `catch` 문을 이용하는 일반적인 api 호출 로직이 적절하여 그렇게 적용했으니 참고 부탁드립니다!

또한 리프레시 토큰의 경우 개발 환경에서는 확인이 불가능하여 배포 환경에 로그인 로직이 적용되어야 토큰 재발급 로직이 정상적으로 적용되었는지 확인이 가능할 것 같습니다! 이 부분은 다음주에 제대로 테스트해보겠습니다!!! 🥹