### PR TITLE
[Feat] 커뮤니티 상세 페이지 피그마 디테일 반영 및 삭제 모달 구현

### DIFF
--- a/src/components/MiniPostActionButton.tsx
+++ b/src/components/MiniPostActionButton.tsx
@@ -1,0 +1,34 @@
+import { cn } from '../lib/utils'
+
+interface MiniPostActionButtonProps {
+  type: 'edit' | 'delete'
+  onClick?: () => void
+}
+
+export const MiniPostActionButton = ({
+  type,
+  onClick,
+}: MiniPostActionButtonProps) => {
+  const isEdit = type === 'edit'
+  const text = isEdit ? '수정' : '삭제'
+  const commonClasses = cn(
+    'flex items-center justify-center transition-colors duration-200',
+    'w-12 h-10 rounded',
+    'whitespace-nowrap', // 줄바꿈 금지
+    'text-base leading-[140%] tracking-[-3%]',
+    'font-normal'
+  )
+
+  const variantClasses = isEdit
+    ? cn('text-primary-default', 'hover:bg-primary-100 hover:font-semibold')
+    : cn(
+        'text-gray-500',
+        'hover:bg-gray-100 hover:text-gray-700 hover:font-semibold'
+      )
+
+  return (
+    <button onClick={onClick} className={cn(commonClasses, variantClasses)}>
+      {text}
+    </button>
+  )
+}

--- a/src/pages/CommunityDetailPage.tsx
+++ b/src/pages/CommunityDetailPage.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react'
-import { useParams } from 'react-router'
+import { useParams, useNavigate } from 'react-router'
 import ShareButton from '../components/ShareButton'
 import LikeButton from '../components/LikeButton'
 import { CommentSection } from '../components/CommunityCommentSection'
 import { Modal } from '../components/Modal'
+import { MiniPostActionButton } from '../components/MiniPostActionButton'
 import { usePostDetail } from '../hooks/queries/usePostDetailQueries'
 
 // URL만 골라내서 <a> 태그로 바꿔주는 함수 추가
@@ -32,10 +33,12 @@ const renderContentWithLinks = (text: string) => {
 
 export default function CommunityDetailPage() {
   const { id } = useParams() // 주소창에서 /posts/1 이면 1을 가져옴
+  const navigate = useNavigate() // 페이지 이동용
+  const myUserId = 2 // 내 유저 ID (작성자 확인용 임시 데이터) 1로 하면 안보이고 2로해야 보임
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
   const [isLiked, setIsLiked] = useState(false)
 
-  // 🚀 msw 요청
+  // msw 요청
   const { data: post, isLoading } = usePostDetail(Number(id))
 
   // 로딩 중이거나 데이터 없을 때 화면
@@ -46,18 +49,17 @@ export default function CommunityDetailPage() {
   return (
     <div className="mx-auto w-full max-w-[800px] px-4 py-10">
       {/* 게시글 상세 영역 */}
-      <header className="mb-6 border-b border-gray-200 pb-6">
+      <header className="mb-6 border-b border-gray-200">
         {/* 카테고리 연동 */}
         <div className="text-primary-default mb-2 text-sm font-semibold">
           {post.category.name}
         </div>
-
-        {/* 제목 & 프로필 연동 */}
+        {/* 제목 & 프로필 연동 (오른쪽 정렬) */}
         <div className="mb-6 flex items-center justify-between">
           <h1 className="text-3xl font-bold text-gray-900">{post.title}</h1>
-          <div className="flex items-center gap-3">
-            <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full bg-gray-200">
-              {/* 프로필 이미지 있으면 보여주기 */}
+          <div className="flex shrink-0 items-center gap-3">
+            <div className="h-12 w-12 shrink-0 overflow-hidden rounded-full bg-gray-200">
+              {/* 프로필 이미지 ... */}
               {post.author.profile_img_url && (
                 <img
                   src={post.author.profile_img_url}
@@ -66,20 +68,35 @@ export default function CommunityDetailPage() {
                 />
               )}
             </div>
-            <span className="text-[text-gray-600 text-base text-sm leading-[140%] font-normal tracking-[-3%]">
+            <span className="text-base leading-[140%] font-semibold tracking-[-3%] text-gray-600">
               {post.author.nickname}
             </span>
           </div>
         </div>
 
-        {/* 조회수 / 좋아요 연동 */}
-        <div className="flex items-center gap-2 text-sm text-gray-400">
-          <span>조회수 {post.view_count}</span>
-          <span>·</span>
-          <span>좋아요 {post.like_count}</span>
-          <span>·</span>
-          {/* 시간은 서버에서 준 날짜로 표시되게 처리 */}
-          <span>{new Date(post.created_at).toLocaleDateString()}</span>
+        {/* 조회수 / 좋아요 연동 & 수정/삭제 버튼 */}
+        <div className="mb-0 flex items-center justify-between">
+          <div className="flex items-center gap-2 text-sm text-gray-400">
+            <span>조회수 {post.view_count}</span>
+            <span>·</span>
+            <span>좋아요 {post.like_count}</span>
+            <span>·</span>
+            <span>{new Date(post.created_at).toLocaleDateString()}</span>
+          </div>
+
+          {post.author.id === myUserId && (
+            <div className="flex items-center">
+              <MiniPostActionButton
+                type="edit"
+                onClick={() => alert('수정 페이지 이동 (구현 예정)')}
+              />
+              <div className="mx-0.5 h-6 w-[1px] bg-gray-300" />
+              <MiniPostActionButton
+                type="delete"
+                onClick={() => setIsDeleteModalOpen(true)}
+              />
+            </div>
+          )}
         </div>
       </header>
 
@@ -104,7 +121,22 @@ export default function CommunityDetailPage() {
       <Modal
         isOpen={isDeleteModalOpen}
         onClose={() => setIsDeleteModalOpen(false)}
-        message="게시글을 정말로 삭제하시겠습니까?"
+        onConfirm={() => {
+          // 2차: 진짜 삭제 진행 후 목록 이동
+          console.log(`${id}번 게시글 삭제 요청!`)
+          setIsDeleteModalOpen(false)
+          alert('게시글이 삭제되었습니다.')
+          navigate('/posts') // 커뮤니티 목록으로 이동
+        }}
+        confirmText="삭제"
+        variant="delete"
+        message={
+          <div className="text-left text-base leading-[140%] font-normal tracking-[-3%] text-gray-700">
+            삭제된 내용은 복구할 수 없습니다.
+            <br />
+            게시글을 정말로 삭제하시겠습니까?
+          </div>
+        }
       />
     </div>
   )


### PR DESCRIPTION
## 📌 관련 이슈
closed #66 
## ✨ 변경 내용
1. 헤더 및 프로필 영역 레이아웃 수정
2. 게시글 액션 버튼 및 하단 구분선 수정
3. 삭제 확인 모달 UI 수정
4. 권한 로직(회원일시 수정 삭제 버튼 뜨고 비회원 일시 안보이게)
## 📸 스크린샷(선택)
<img width="1708" height="814" alt="스크린샷 2026-03-21 오후 7 49 52" src="https://github.com/user-attachments/assets/fdf1b3ae-7139-40b2-ba6a-9797dc19b71b" />

## 📚 참고사항
