### PR TITLE
[Feature] presigned url 발급 msw & api 요청 로직 추가

### DIFF
--- a/src/api/imageAPI.ts
+++ b/src/api/imageAPI.ts
@@ -1,0 +1,26 @@
+import axios from 'axios'
+import { instance } from './instance'
+import type { PreSignedUrlResponse } from '../types/api-response-types/image'
+
+// Presigned URL 발급 요청
+async function getPresignedUrlAPI(fileName: string) {
+  const response = await instance.put<PreSignedUrlResponse>(
+    '/qna/questions/presigned-url',
+    {
+      file_name: fileName,
+    }
+  )
+  return response.data
+}
+
+// Presigned URL을 이용해 S3에 이미지 업로드
+async function uploadImageToS3(presignedUrl: string, file: File) {
+  const response = await axios.put(presignedUrl, file, {
+    headers: {
+      'Content-Type': file.type,
+    },
+  })
+  return response.data
+}
+
+export { getPresignedUrlAPI, uploadImageToS3 }

--- a/src/components/editor/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/components/editor/MarkdownEditor/MarkdownEditor.tsx
@@ -1,4 +1,5 @@
 import {
+  useEffect,
   useRef,
   useState,
   type ChangeEvent,
@@ -22,7 +23,19 @@ export default function MarkdownEditor({
   const editorWrapperRef = useRef<HTMLDivElement | null>(null)
   const fileInputRef = useRef<HTMLInputElement | null>(null)
   const [selectedFile, setSelectedFile] = useState<File | null>(null)
-  const { isUploading, imgUrl } = useImageUpload(selectedFile)
+  const [pendingPlaceholder, setPendingPlaceholder] = useState<string>('')
+  const { imgUrl } = useImageUpload(selectedFile)
+
+  // presigned url 발급 + S3 이미지 업로드 로직 관리
+  useEffect(() => {
+    if (!selectedFile || !pendingPlaceholder || !imgUrl) return
+
+    const markdownImage = `![${selectedFile.name}](${imgUrl})`
+
+    setValue((prev) => prev.replace(pendingPlaceholder, markdownImage))
+    setPendingPlaceholder('')
+    setSelectedFile(null)
+  }, [selectedFile, pendingPlaceholder, imgUrl, value])
 
   // textarea 찾기
   const getTextarea = () => {
@@ -188,23 +201,21 @@ export default function MarkdownEditor({
   // 이미지 업로드
   const handleImageUpload = (event: ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0]
-    if (file) setSelectedFile(file)
     const textarea = getTextarea()
     const currentValue = value ?? ''
 
     if (!file || !textarea) return
 
+    const newPlaceholder = `__image_uploading_${Date.now()}__`
+
     const start = textarea.selectionStart
     const end = textarea.selectionEnd
-    // const imageUrl = URL.createObjectURL(file)
-    const markdown = isUploading
-      ? 'image uploading...'
-      : `![Image name](${imgUrl})`
-
     const nextValue =
-      currentValue.slice(0, start) + markdown + currentValue.slice(end)
+      currentValue.slice(0, start) + newPlaceholder + currentValue.slice(end)
 
-    updateSelection(nextValue, start, start + markdown.length)
+    updateSelection(nextValue, start, start + newPlaceholder.length)
+    setPendingPlaceholder(newPlaceholder)
+    setSelectedFile(file)
 
     event.target.value = ''
   }

--- a/src/components/editor/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/components/editor/MarkdownEditor/MarkdownEditor.tsx
@@ -1,11 +1,13 @@
 import {
   useRef,
+  useState,
   type ChangeEvent,
   type Dispatch,
   type SetStateAction,
 } from 'react'
 import MDEditor from '@uiw/react-md-editor'
 import EditorToolbar from './EditorToolbar'
+import { useImageUpload } from '../../../hooks/useImageUpload'
 
 interface MarkdownEditorProps {
   value: string
@@ -19,6 +21,8 @@ export default function MarkdownEditor({
   // 에디터
   const editorWrapperRef = useRef<HTMLDivElement | null>(null)
   const fileInputRef = useRef<HTMLInputElement | null>(null)
+  const [selectedFile, setSelectedFile] = useState<File | null>(null)
+  const { isUploading, imgUrl } = useImageUpload(selectedFile)
 
   // textarea 찾기
   const getTextarea = () => {
@@ -184,6 +188,7 @@ export default function MarkdownEditor({
   // 이미지 업로드
   const handleImageUpload = (event: ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0]
+    if (file) setSelectedFile(file)
     const textarea = getTextarea()
     const currentValue = value ?? ''
 
@@ -191,8 +196,10 @@ export default function MarkdownEditor({
 
     const start = textarea.selectionStart
     const end = textarea.selectionEnd
-    const imageUrl = URL.createObjectURL(file)
-    const markdown = `![Image name](${imageUrl})`
+    // const imageUrl = URL.createObjectURL(file)
+    const markdown = isUploading
+      ? 'image uploading...'
+      : `![Image name](${imgUrl})`
 
     const nextValue =
       currentValue.slice(0, start) + markdown + currentValue.slice(end)

--- a/src/hooks/useImageUpload.ts
+++ b/src/hooks/useImageUpload.ts
@@ -8,16 +8,21 @@ export function useImageUpload(file: File | null) {
   const { showToast } = useToast()
 
   useEffect(() => {
-    if (isUploading || !file) return
+    if (!file) return
 
     const handleImageUpload = async () => {
       try {
         setIsUploading(true)
+        setImgUrl('')
+
         const { presigned_url: newPresignedUrl, img_url: newImgUrl } =
           await getPresignedUrlAPI(file.name)
+
         await uploadImageToS3(newPresignedUrl, file)
+
         setImgUrl(newImgUrl)
       } catch (err) {
+        setImgUrl('')
         showToast(
           'default',
           '이미지 업로드 실패',

--- a/src/hooks/useImageUpload.ts
+++ b/src/hooks/useImageUpload.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react'
+import { getPresignedUrlAPI, uploadImageToS3 } from '../api/imageAPI'
+import { useToast } from './useToast'
+
+export function useImageUpload(file: File | null) {
+  const [isUploading, setIsUploading] = useState<boolean>(false)
+  const [imgUrl, setImgUrl] = useState<string>('')
+  const { showToast } = useToast()
+
+  useEffect(() => {
+    if (isUploading || !file) return
+
+    const handleImageUpload = async () => {
+      try {
+        setIsUploading(true)
+        const { presigned_url: newPresignedUrl, img_url: newImgUrl } =
+          await getPresignedUrlAPI(file.name)
+        await uploadImageToS3(newPresignedUrl, file)
+        setImgUrl(newImgUrl)
+      } catch (err) {
+        showToast(
+          'default',
+          '이미지 업로드 실패',
+          '이미지를 다시 업로드해주세요.'
+        )
+      } finally {
+        setIsUploading(false)
+      }
+    }
+
+    handleImageUpload()
+  }, [file])
+
+  return { isUploading, imgUrl }
+}

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -8,6 +8,10 @@ import {
 } from './handlers/post-handlers'
 import { commentHandlers } from './handlers/comment-handlers'
 import { getRefreshTokenMOCK } from './handlers/auth-handlers'
+import {
+  getPresignedUrlMOCK,
+  uploadImageToS3MOCK,
+} from './handlers/image-handlers'
 
 export const handlers = [
   getPostCategoriesMOCK,
@@ -16,5 +20,7 @@ export const handlers = [
   getPostDetailMOCK,
   updatePostMOCK,
   getRefreshTokenMOCK,
+  getPresignedUrlMOCK,
+  uploadImageToS3MOCK,
   ...commentHandlers,
 ]

--- a/src/mocks/handlers/image-handlers.ts
+++ b/src/mocks/handlers/image-handlers.ts
@@ -1,0 +1,37 @@
+import { delay, http, HttpResponse } from 'msw'
+import type { PreSignedUrlResponse } from '../../types/api-response-types/image'
+
+const getPresignedUrlMOCK = http.put(
+  `/qna/questions/presigned-url`,
+  async ({ request }) => {
+    await delay(500)
+
+    const body = await request.json()
+
+    if (!body) {
+      return HttpResponse.json(
+        { error_detail: '지원하지 않는 파일 형식입니다.' },
+        { status: 400 }
+      )
+    }
+
+    const response: PreSignedUrlResponse = {
+      presigned_url: `https://fake/presigned_url/file_name`,
+      img_url: `https://placehold.co/600x400?text=fake-image.png`,
+      key: `key/file_name`,
+    }
+
+    return HttpResponse.json(response, { status: 200 })
+  }
+)
+
+const uploadImageToS3MOCK = http.put(
+  `https://fake/presigned_url/file_name`,
+  async () => {
+    await delay(500)
+
+    return HttpResponse.json({ status: 200 })
+  }
+)
+
+export { getPresignedUrlMOCK, uploadImageToS3MOCK }

--- a/src/mocks/handlers/image-handlers.ts
+++ b/src/mocks/handlers/image-handlers.ts
@@ -1,10 +1,11 @@
 import { delay, http, HttpResponse } from 'msw'
 import type { PreSignedUrlResponse } from '../../types/api-response-types/image'
+import { MSW_BASE_URL } from '../../constants/baseUrl'
 
 const getPresignedUrlMOCK = http.put(
-  `/qna/questions/presigned-url`,
+  `${MSW_BASE_URL}/qna/questions/presigned-url`,
   async ({ request }) => {
-    await delay(500)
+    await delay(1000)
 
     const body = await request.json()
 
@@ -28,7 +29,7 @@ const getPresignedUrlMOCK = http.put(
 const uploadImageToS3MOCK = http.put(
   `https://fake/presigned_url/file_name`,
   async () => {
-    await delay(500)
+    await delay(1000)
 
     return HttpResponse.json({ status: 200 })
   }

--- a/src/types/api-response-types/image.ts
+++ b/src/types/api-response-types/image.ts
@@ -1,0 +1,5 @@
+export interface PreSignedUrlResponse {
+  presigned_url: string
+  img_url: string
+  key: string
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #65

## ✨ 변경 내용
<!-- 변경한 내용을 간략하게 설명해주세요. -->
- presigned url 발급 API와 S3 이미지 업로드 API의 msw 로직 추가
- response 타입 추가
- 마크다운 에디터 컴포넌트에 해당 로직 적용

## 📸 스크린샷(선택)
<!-- 스크린샷이 있다면 첨부해주세요. -->
<img width="1433" height="654" alt="image" src="https://github.com/user-attachments/assets/112ae6e8-c7d2-4c5d-af03-84facae129ba" />


## 📚 참고사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 게시글 작성 API 등 이미지 데이터를 API 요청 `request` 값으로 사용해야 하는 경우에는 아래의 `imgUrl` 값을 사용해주셔야 합니다.

  ```
  const { imgUrl } = useImageUpload(selectedFile)
  ```
- 마크다운 에디터 컴포넌트에 `presigned url` 발급 로직이 작동할 때 `placeholder` 값이 변하는 로직을 추가했습니다.
- 일단 `delay`를 이용해서 실제 API 요청이 작동하는 것과 비슷한 느낌을 주려고 했는데, 정확하게 작동하는 지는 API 테스트를 거쳐봐야 할 것 같습니다!