### PR TITLE
[Feat] 내 정보 조회 API 연결 및 사용자 정보 전역 상태 관리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,8 +5,24 @@ import PostList from './pages/PostList'
 import PostCreate from './pages/PostCreate'
 import PostEdit from './pages/PostEdit'
 import CommunityDetailPage from './pages/CommunityDetailPage'
+import { useEffect } from 'react'
+import { useAccessTokenStore } from './store/useAccessTokenStore'
+import { useUserInfo } from './hooks/queries/useUserQueries'
+import { useUserInfoStore } from './store/useUserInfoStore'
 
 function App() {
+  const { accessToken } = useAccessTokenStore()
+  const { setUserInfo } = useUserInfoStore()
+  const { data: newUserInfo, isSuccess } = useUserInfo({
+    enabled: !!accessToken,
+  })
+
+  useEffect(() => {
+    if (isSuccess) {
+      setUserInfo(newUserInfo)
+    }
+  }, [isSuccess])
+
   return (
     <Routes>
       <Route element={<RootLayout />}>

--- a/src/api/userAPI.ts
+++ b/src/api/userAPI.ts
@@ -1,0 +1,9 @@
+import type { GetUserInfoResponse } from '../types/api-response-types/user'
+import { apiInstance } from './apiInstance'
+
+async function getUserInfoAPI() {
+  const response = await apiInstance.get<GetUserInfoResponse>('/accounts/me')
+  return response.data
+}
+
+export { getUserInfoAPI }

--- a/src/hooks/queries/useUserQueries.ts
+++ b/src/hooks/queries/useUserQueries.ts
@@ -1,0 +1,15 @@
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query'
+import type { GetUserInfoResponse } from '../../types/api-response-types/user'
+import { getUserInfoAPI } from '../../api/userAPI'
+
+function useUserInfo(
+  options?: Omit<UseQueryOptions<GetUserInfoResponse>, 'queryKey' | 'queryFn'>
+) {
+  return useQuery<GetUserInfoResponse>({
+    queryKey: ['getUserInfo'],
+    queryFn: getUserInfoAPI,
+    ...options,
+  })
+}
+
+export { useUserInfo }

--- a/src/store/useUserInfoStore.ts
+++ b/src/store/useUserInfoStore.ts
@@ -1,0 +1,22 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+import type { GetUserInfoResponse } from '../types/api-response-types/user'
+
+interface UserInfoState {
+  userInfo: GetUserInfoResponse | null
+  setUserInfo: (newUserInfo: any) => void
+  clearUserInfo: () => void
+}
+
+export const useUserInfoStore = create<UserInfoState>()(
+  persist(
+    (set) => ({
+      userInfo: null,
+
+      setUserInfo: (newUserInfo) => set({ userInfo: newUserInfo }),
+
+      clearUserInfo: () => set({ userInfo: null }),
+    }),
+    { name: 'infoStorage' }
+  )
+)

--- a/src/types/api-response-types/user.ts
+++ b/src/types/api-response-types/user.ts
@@ -1,0 +1,14 @@
+interface GetUserInfoResponse {
+  id: number
+  email: string
+  name: string
+  nickname: string
+  phoneNumber: string
+  gender: 'M' | 'F'
+  birthday: string
+  profileImgUrl: string
+  createdAt: string
+  updatedAt: string
+}
+
+export type { GetUserInfoResponse }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #79

## ✨ 변경 내용
<!-- 변경한 내용을 간략하게 설명해주세요. -->
- 액세스 토큰 보유 시 내 정보 조회 API 실행
- 사용자 정보를 저장하고 관리하는 전역 상태 추가
- 내 정보 조회 API 요청 후 응답값을 전역 상태에 저장

## 📸 스크린샷(선택)
<!-- 스크린샷이 있다면 첨부해주세요. -->
<img width="1437" height="603" alt="image" src="https://github.com/user-attachments/assets/29ad96a5-85f8-45bd-bb78-c94bb904ca4a" />

## 📚 참고사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 이후 진행할 작업은 아래와 같습니다.
  - 액세스 토큰 보유 시 로그인한 상태라고 판단하고 헤더 UI 변경
  - 로그인한 상태일 때 변경된 헤더 UI에 사용자 정보 반영