### PR TITLE
[Feat] 댓글 수정 API 연동 및 인라인 수정 UI 구현

### DIFF
--- a/src/api/commentAPI.ts
+++ b/src/api/commentAPI.ts
@@ -25,3 +25,15 @@ export async function deleteCommentAPI(postId: number, commentId: number) {
   )
   return response.data
 }
+
+export async function updateCommentAPI(
+  postId: number,
+  commentId: number,
+  content: string
+) {
+  const response = await apiInstance.put(
+    `/posts/${postId}/comments/${commentId}`,
+    { content }
+  )
+  return response.data
+}

--- a/src/components/CommunityCommentItem.tsx
+++ b/src/components/CommunityCommentItem.tsx
@@ -1,9 +1,12 @@
+import { useState } from 'react'
+
 interface CommentItemProps {
   authorName: string
   date: string
   content: string
   isMyComment?: boolean
   onDelete?: () => void
+  onEdit?: (newContent: string) => void
 }
 
 export const CommentItem = ({
@@ -12,7 +15,29 @@ export const CommentItem = ({
   content,
   isMyComment = false,
   onDelete,
+  onEdit,
 }: CommentItemProps) => {
+  // 수정 모드 관리 상태
+  const [isEditing, setIsEditing] = useState(false)
+  const [editContent, setEditContent] = useState(content)
+
+  // 수정 완료 버튼 눌렀을 때
+  const handleSave = () => {
+    if (!editContent.trim()) {
+      alert('수정할 내용을 입력해주세요.')
+      return
+    }
+    if (onEdit) {
+      onEdit(editContent)
+      setIsEditing(false)
+    }
+  }
+
+  //  취소 버튼 눌렀을 때
+  const handleCancel = () => {
+    setIsEditing(false) // 수정 모드 끄기
+    setEditContent(content) // 쓰던 거 날리고 원래 내용으로 복구
+  }
   return (
     <div className="flex gap-3 border-b border-gray-200 py-5 last:border-0">
       {/* 왼쪽 프로필 이미지 */}
@@ -25,9 +50,15 @@ export const CommentItem = ({
           </span>
           <span className="text-xs text-gray-400">{date}</span>
 
-          {isMyComment && (
+          {isMyComment && !isEditing && (
             <div className="flex items-center gap-2">
               <span className="text-[10px] text-gray-300">|</span>
+              <button
+                onClick={() => setIsEditing(true)}
+                className="cursor-pointer text-xs font-medium text-gray-400 hover:underline"
+              >
+                수정
+              </button>
               <button
                 onClick={onDelete}
                 className="text-primary-default cursor-pointer text-xs font-medium hover:underline"
@@ -37,9 +68,36 @@ export const CommentItem = ({
             </div>
           )}
         </div>
-        <div className="text-text-main mt-1 text-sm leading-relaxed">
-          {content}
-        </div>
+        {isEditing ? (
+          // 수정 모드일 때 (입력창 + 취소/저장 버튼)
+          <div className="mt-2 flex flex-col gap-2">
+            <textarea
+              value={editContent}
+              onChange={(e) => setEditContent(e.target.value)}
+              className="w-full resize-none rounded-lg border border-gray-300 p-3 text-sm text-gray-800 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+              rows={3}
+            />
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={handleCancel}
+                className="cursor-pointer rounded-md bg-gray-100 px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-200"
+              >
+                취소
+              </button>
+              <button
+                onClick={handleSave}
+                className="bg-primary-400 hover:bg-primary-default cursor-pointer rounded-md px-3 py-1.5 text-xs font-medium text-white"
+              >
+                수정 완료
+              </button>
+            </div>
+          </div>
+        ) : (
+          // 일반 모드일 때 (기존 텍스트)
+          <div className="text-text-main mt-1 text-sm leading-relaxed whitespace-pre-wrap">
+            {content}
+          </div>
+        )}
       </div>
     </div>
   )

--- a/src/components/CommunityCommentSection.tsx
+++ b/src/components/CommunityCommentSection.tsx
@@ -9,6 +9,7 @@ import {
   useComments,
   useCreateComment,
   useDeleteComment,
+  useUpdateComment,
 } from '../hooks/queries/useCommentQueries'
 
 export const CommentSection = () => {
@@ -22,6 +23,7 @@ export const CommentSection = () => {
   const { data, isLoading } = useComments(postId)
   const { mutate: createComment } = useCreateComment(postId)
   const { mutate: deleteComment } = useDeleteComment(postId)
+  const { mutate: updateComment } = useUpdateComment(postId)
 
   // 데이터가 아직 안 왔으면 로딩 표시
   if (isLoading) {
@@ -70,7 +72,7 @@ export const CommentSection = () => {
         <CommentSort sortOrder={sortOrder} onChange={setSortOrder} />
       </div>
 
-      {/* 3. 댓글 리스트 */}
+      {/* 댓글 리스트 */}
       <div className="flex flex-col">
         {sortedComments.map((comment) => (
           <CommentItem
@@ -82,6 +84,9 @@ export const CommentSection = () => {
             onDelete={() => {
               setDeleteTargetId(comment.id)
               setIsModalOpen(true)
+            }}
+            onEdit={(newContent) => {
+              updateComment({ commentId: comment.id, content: newContent })
             }}
           />
         ))}

--- a/src/hooks/queries/useCommentQueries.ts
+++ b/src/hooks/queries/useCommentQueries.ts
@@ -3,6 +3,7 @@ import {
   getCommentsAPI,
   createCommentAPI,
   deleteCommentAPI,
+  updateCommentAPI,
 } from '../../api/commentAPI'
 import type { CreateCommentRequest } from '../../types'
 
@@ -27,6 +28,22 @@ export function useDeleteComment(postId: number) {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: (commentId: number) => deleteCommentAPI(postId, commentId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['comments', postId] })
+    },
+  })
+}
+
+export function useUpdateComment(postId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      commentId,
+      content,
+    }: {
+      commentId: number
+      content: string
+    }) => updateCommentAPI(postId, commentId, content),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['comments', postId] })
     },


### PR DESCRIPTION
## 📌 관련 이슈
closed #104 

## ✨ 변경 내용
1. 댓글 수정 API 연결
2. 댓글 수정 성공시 댓글 최신 목록 다시 불러오도록 동기화
3. 인라인 수정모드 적용 (피그마에 ui 없어서 멋대로...)
4. 댓글 수정시 내용이 비어있을때 예외처리
5. 줄바꿈이 안되길래 줄바꿈되도록 whitespace-pre-wrap 추가해서 픽스
   
## 📸 스크린샷(선택)
<img width="1728" height="899" alt="스크린샷 2026-03-29 오전 2 18 16" src="https://github.com/user-attachments/assets/8342c1a8-6f6b-43d6-9b6c-ba1c26ac756c" />
<img width="1728" height="901" alt="스크린샷 2026-03-29 오전 2 18 24" src="https://github.com/user-attachments/assets/990554a8-fb87-40d2-8c02-37f09922132b" />


## 📚 참고사항
.