### PR TITLE
[Feat] 댓글 태그 유저 검색 API 연동 및 드롭다운 UI 구현

### DIFF
--- a/src/api/commentAPI.ts
+++ b/src/api/commentAPI.ts
@@ -37,3 +37,10 @@ export async function updateCommentAPI(
   )
   return response.data
 }
+
+export async function searchUserAPI(nickname: string) {
+  const response = await apiInstance.get(`/posts/user/search`, {
+    params: { nickname },
+  })
+  return response.data
+}

--- a/src/api/commentAPI.ts
+++ b/src/api/commentAPI.ts
@@ -25,3 +25,15 @@ export async function deleteCommentAPI(postId: number, commentId: number) {
   )
   return response.data
 }
+
+export async function updateCommentAPI(
+  postId: number,
+  commentId: number,
+  content: string
+) {
+  const response = await apiInstance.put(
+    `/posts/${postId}/comments/${commentId}`,
+    { content }
+  )
+  return response.data
+}

--- a/src/components/CommentInput.tsx
+++ b/src/components/CommentInput.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from 'react'
 import { CommentButton } from './CommentButton'
 import { cn } from '../lib/utils'
-import { MOCK_MENTION_USERS } from '../mocks/data/users'
+import { useSearchUser } from '../hooks/queries/useCommentQueries'
 
 interface CommentInputProps {
   onSubmit?: (content: string) => void
@@ -14,6 +14,7 @@ export const CommentInput = ({ onSubmit }: CommentInputProps) => {
   const [showMentionList, setShowMentionList] = useState(false)
   const [mentionFilter, setMentionFilter] = useState('')
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const { data: searchResults = [] } = useSearchUser(mentionFilter)
 
   useEffect(() => {
     if (textareaRef.current) {
@@ -69,26 +70,35 @@ export const CommentInput = ({ onSubmit }: CommentInputProps) => {
   }
   return (
     <div className="relative w-full">
-      {' '}
       {showMentionList && (
         <div className="absolute bottom-full left-0 z-50 mb-2 w-[280px] rounded-xl bg-white p-3 shadow-[0_4px_16px_0_rgba(0,0,0,0.25)]">
-          <ul className="flex max-h-[116px] flex-col gap-[10px] overflow-y-auto pr-1 [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-[#BDBDBD] [&::-webkit-scrollbar-track]:bg-transparent">
-            {MOCK_MENTION_USERS.filter((u) =>
-              u.nickname.includes(mentionFilter)
-            ).map((user) => (
+          <ul
+            className={cn(
+              'flex max-h-28 flex-col gap-2.5 overflow-y-auto pr-1',
+              '[&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent',
+              '[&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-gray-400'
+            )}
+          >
+            {/* 서버에서 받아온 유저 목록 */}
+            {searchResults.map((user: any) => (
               <li key={user.id}>
                 <button
                   type="button"
                   onClick={() => handleUserSelect(user.nickname)}
-                  className="flex w-full items-center gap-3 rounded-lg px-2 py-1.5 text-left text-sm transition-colors hover:bg-gray-200"
+                  className={cn(
+                    'flex w-full items-center gap-3 rounded-lg px-2 py-1.5 text-left text-sm',
+                    'transition-colors hover:bg-gray-200'
+                  )}
                 >
                   <div className="h-6 w-6 shrink-0 overflow-hidden rounded-full bg-gray-100">
-                    {user.profile_img_url && (
+                    {user.profile_img_url ? (
                       <img
                         src={user.profile_img_url}
                         alt={user.nickname}
                         className="h-full w-full object-cover"
                       />
+                    ) : (
+                      <div className="h-full w-full bg-gray-200"></div>
                     )}
                   </div>
                   <span className="font-medium text-gray-900">
@@ -98,10 +108,8 @@ export const CommentInput = ({ onSubmit }: CommentInputProps) => {
               </li>
             ))}
 
-            {/* 검색 결과가 없을 때 */}
-            {MOCK_MENTION_USERS.filter((u) =>
-              u.nickname.includes(mentionFilter)
-            ).length === 0 && (
+            {/* 검색 결과가 없을 때 방어 로직 */}
+            {searchResults.length === 0 && mentionFilter.trim() !== '' && (
               <li className="p-3 text-center text-xs text-gray-400">
                 검색 결과가 없습니다.
               </li>

--- a/src/components/CommunityCommentItem.tsx
+++ b/src/components/CommunityCommentItem.tsx
@@ -1,9 +1,12 @@
+import { useState } from 'react'
+
 interface CommentItemProps {
   authorName: string
   date: string
   content: string
   isMyComment?: boolean
   onDelete?: () => void
+  onEdit?: (newContent: string) => void
 }
 
 export const CommentItem = ({
@@ -12,7 +15,29 @@ export const CommentItem = ({
   content,
   isMyComment = false,
   onDelete,
+  onEdit,
 }: CommentItemProps) => {
+  // 수정 모드 관리 상태
+  const [isEditing, setIsEditing] = useState(false)
+  const [editContent, setEditContent] = useState(content)
+
+  // 수정 완료 버튼 눌렀을 때
+  const handleSave = () => {
+    if (!editContent.trim()) {
+      alert('수정할 내용을 입력해주세요.')
+      return
+    }
+    if (onEdit) {
+      onEdit(editContent)
+      setIsEditing(false)
+    }
+  }
+
+  //  취소 버튼 눌렀을 때
+  const handleCancel = () => {
+    setIsEditing(false) // 수정 모드 끄기
+    setEditContent(content) // 쓰던 거 날리고 원래 내용으로 복구
+  }
   return (
     <div className="flex gap-3 border-b border-gray-200 py-5 last:border-0">
       {/* 왼쪽 프로필 이미지 */}
@@ -25,9 +50,15 @@ export const CommentItem = ({
           </span>
           <span className="text-xs text-gray-400">{date}</span>
 
-          {isMyComment && (
+          {isMyComment && !isEditing && (
             <div className="flex items-center gap-2">
               <span className="text-[10px] text-gray-300">|</span>
+              <button
+                onClick={() => setIsEditing(true)}
+                className="cursor-pointer text-xs font-medium text-gray-400 hover:underline"
+              >
+                수정
+              </button>
               <button
                 onClick={onDelete}
                 className="text-primary-default cursor-pointer text-xs font-medium hover:underline"
@@ -37,9 +68,36 @@ export const CommentItem = ({
             </div>
           )}
         </div>
-        <div className="text-text-main mt-1 text-sm leading-relaxed">
-          {content}
-        </div>
+        {isEditing ? (
+          // 수정 모드일 때 (입력창 + 취소/저장 버튼)
+          <div className="mt-2 flex flex-col gap-2">
+            <textarea
+              value={editContent}
+              onChange={(e) => setEditContent(e.target.value)}
+              className="w-full resize-none rounded-lg border border-gray-300 p-3 text-sm text-gray-800 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+              rows={3}
+            />
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={handleCancel}
+                className="cursor-pointer rounded-md bg-gray-100 px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-200"
+              >
+                취소
+              </button>
+              <button
+                onClick={handleSave}
+                className="bg-primary-400 hover:bg-primary-default cursor-pointer rounded-md px-3 py-1.5 text-xs font-medium text-white"
+              >
+                수정 완료
+              </button>
+            </div>
+          </div>
+        ) : (
+          // 일반 모드일 때 (기존 텍스트)
+          <div className="text-text-main mt-1 text-sm leading-relaxed whitespace-pre-wrap">
+            {content}
+          </div>
+        )}
       </div>
     </div>
   )

--- a/src/components/CommunityCommentSection.tsx
+++ b/src/components/CommunityCommentSection.tsx
@@ -9,6 +9,7 @@ import {
   useComments,
   useCreateComment,
   useDeleteComment,
+  useUpdateComment,
 } from '../hooks/queries/useCommentQueries'
 
 export const CommentSection = () => {
@@ -22,6 +23,7 @@ export const CommentSection = () => {
   const { data, isLoading } = useComments(postId)
   const { mutate: createComment } = useCreateComment(postId)
   const { mutate: deleteComment } = useDeleteComment(postId)
+  const { mutate: updateComment } = useUpdateComment(postId)
 
   // 데이터가 아직 안 왔으면 로딩 표시
   if (isLoading) {
@@ -70,7 +72,7 @@ export const CommentSection = () => {
         <CommentSort sortOrder={sortOrder} onChange={setSortOrder} />
       </div>
 
-      {/* 3. 댓글 리스트 */}
+      {/* 댓글 리스트 */}
       <div className="flex flex-col">
         {sortedComments.map((comment) => (
           <CommentItem
@@ -82,6 +84,9 @@ export const CommentSection = () => {
             onDelete={() => {
               setDeleteTargetId(comment.id)
               setIsModalOpen(true)
+            }}
+            onEdit={(newContent) => {
+              updateComment({ commentId: comment.id, content: newContent })
             }}
           />
         ))}

--- a/src/hooks/queries/useCommentQueries.ts
+++ b/src/hooks/queries/useCommentQueries.ts
@@ -4,6 +4,7 @@ import {
   createCommentAPI,
   deleteCommentAPI,
   updateCommentAPI,
+  searchUserAPI,
 } from '../../api/commentAPI'
 import type { CreateCommentRequest } from '../../types'
 
@@ -47,5 +48,15 @@ export function useUpdateComment(postId: number) {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['comments', postId] })
     },
+  })
+}
+export function useSearchUser(nickname: string) {
+  return useQuery({
+    queryKey: ['searchUser', nickname],
+    queryFn: () => searchUserAPI(nickname),
+    // nickname이 빈 칸이 아닐 때만 API 쏘기 (서버 과부하 방지)
+    enabled: !!nickname,
+    // 키보드 칠 때마다 너무 API 쏘지 않게 살짝 딜레이를 주는 캐시 설정
+    staleTime: 1000 * 60 * 5,
   })
 }

--- a/src/hooks/queries/useCommentQueries.ts
+++ b/src/hooks/queries/useCommentQueries.ts
@@ -3,6 +3,7 @@ import {
   getCommentsAPI,
   createCommentAPI,
   deleteCommentAPI,
+  updateCommentAPI,
 } from '../../api/commentAPI'
 import type { CreateCommentRequest } from '../../types'
 
@@ -27,6 +28,22 @@ export function useDeleteComment(postId: number) {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: (commentId: number) => deleteCommentAPI(postId, commentId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['comments', postId] })
+    },
+  })
+}
+
+export function useUpdateComment(postId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      commentId,
+      content,
+    }: {
+      commentId: number
+      content: string
+    }) => updateCommentAPI(postId, commentId, content),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['comments', postId] })
     },


### PR DESCRIPTION
## 📌 관련 이슈
closed #109 

## ✨ 변경 내용
1. 유저 검색 API 연동 및 동기화
2. 태그 팝업(드롭다운) UI 구현 및 실제 데이터 연결
3. 스타일링 유틸리티 코드로 변경 및 최적화
## 📸 스크린샷(선택)
<img width="1728" height="904" alt="스크린샷 2026-03-30 오전 6 50 30" src="https://github.com/user-attachments/assets/68d6f6c4-45c3-4c99-961c-ef9b79fb346a" />

## 📚 참고사항
<!-- 참고할 사항이 있다면 적어주세요. -->
