### PR TITLE
[Refactor] UI 다듬기 및 게시글 목록 개선

### DIFF
--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
-import { MSW_BASE_URL } from '../constants/baseUrl'
+import { API_BASE_URL } from '../constants/baseUrl'
 
 export const instance = axios.create({
-  baseURL: MSW_BASE_URL,
+  baseURL: API_BASE_URL,
   withCredentials: true,
 })

--- a/src/api/postAPI.ts
+++ b/src/api/postAPI.ts
@@ -26,10 +26,8 @@ async function getPostsAPI(params: {
 
 // 카테고리 목록 조회
 async function getPostCategoriesAPI() {
-  const response = await apiInstance.get<{ categories: PostCategory[] }>(
-    '/posts/categories'
-  )
-  return response.data?.categories || []
+  const response = await apiInstance.get<PostCategory[]>('/posts/categories')
+  return response.data || []
 }
 
 // 게시글 생성

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -23,12 +23,12 @@ export default function Dropdown({
   }, [selectedProp, placeholder])
 
   return (
-    <div className="relative inline-block">
+    <div className="relative w-full">
       <button
         type="button"
         onClick={() => setIsOpen((prev) => !prev)}
         className={cn(
-          'border-gray-disabled flex h-10 items-center justify-between rounded border bg-gray-100 px-4 text-sm transition-all outline-none',
+          'border-gray-disabled flex h-10 w-full items-center justify-between rounded border bg-gray-100 px-4 text-sm transition-all outline-none',
           isOpen ? 'text-text-main font-medium' : 'text-text-disabled'
         )}
       >
@@ -42,7 +42,7 @@ export default function Dropdown({
       </button>
 
       {isOpen && (
-        <div className="shadow-box bg-surface-default absolute top-11 right-0 z-50 -mr-10 flex min-w-[140px] flex-col rounded border border-gray-500 py-1">
+        <div className="shadow-box bg-surface-default absolute top-11 left-0 z-50 flex w-full flex-col rounded border border-gray-500 py-1">
           <ul className="scrollbar scrollbar-w-2 scrollbar-thumb-gray-disabled scrollbar-track-transparent scrollbar-thumb-rounded-sm flex max-h-60 flex-col gap-2 overflow-y-auto p-1">
             {options.map((option) => (
               <li

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -23,12 +23,12 @@ export default function Dropdown({
   }, [selectedProp, placeholder])
 
   return (
-    <div className="relative flex w-full flex-col gap-0">
+    <div className="relative inline-block">
       <button
         type="button"
         onClick={() => setIsOpen((prev) => !prev)}
         className={cn(
-          'border-gray-disabled flex h-10 w-full items-center justify-between rounded border bg-gray-100 px-4 text-sm transition-all outline-none',
+          'border-gray-disabled flex h-10 items-center justify-between rounded border bg-gray-100 px-4 text-sm transition-all outline-none',
           isOpen ? 'text-text-main font-medium' : 'text-text-disabled'
         )}
       >
@@ -42,7 +42,7 @@ export default function Dropdown({
       </button>
 
       {isOpen && (
-        <div className="shadow-box bg-surface-default absolute top-11 z-50 flex w-full flex-col rounded border border-gray-500 py-1">
+        <div className="shadow-box bg-surface-default absolute top-11 right-0 z-50 -mr-10 flex min-w-[140px] flex-col rounded border border-gray-500 py-1">
           <ul className="scrollbar scrollbar-w-2 scrollbar-thumb-gray-disabled scrollbar-track-transparent scrollbar-thumb-rounded-sm flex max-h-60 flex-col gap-2 overflow-y-auto p-1">
             {options.map((option) => (
               <li
@@ -53,7 +53,7 @@ export default function Dropdown({
                   setIsOpen(false)
                 }}
                 className={cn(
-                  'hover:bg-primary-100 flex h-12 w-full shrink-0 cursor-pointer items-center justify-between rounded-sm px-4 py-2 text-sm transition-colors',
+                  'hover:bg-primary-100 flex h-12 w-full shrink-0 cursor-pointer items-center justify-center rounded-sm px-2 py-2 text-center text-sm transition-colors',
                   selected === option
                     ? 'text-primary-default font-semibold'
                     : 'text-text-main'

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -1,4 +1,4 @@
-import { ThumbsUp, MessageCircle, Eye } from 'lucide-react'
+import { ThumbsUp, MessageCircle, Eye, User } from 'lucide-react'
 
 export interface PostCardProps {
   id: string
@@ -74,17 +74,9 @@ function PostCard({ post, onClick }: Props) {
 
           <div className="flex items-center gap-4">
             <div className="flex items-center gap-2">
-              {post.author.profile_img_url ? (
-                <img
-                  src={post.author.profile_img_url}
-                  alt="author-profile-image"
-                  className="size-6 rounded-full object-cover"
-                />
-              ) : (
-                <div className="flex size-6 items-center justify-center rounded-full bg-gray-200">
-                  👤
-                </div>
-              )}
+              <div className="flex size-6 items-center justify-center rounded-full bg-gray-200">
+                <User className="size-4 text-gray-500" />
+              </div>
               <span className="text-12 text-text-sub">
                 {post.author.nickname}
               </span>

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -41,7 +41,7 @@ function PostCard({ post, onClick }: Props) {
   return (
     <div
       onClick={onClick}
-      className="border-gray-250 flex h-52 w-full cursor-pointer gap-6 border-b py-8 transition hover:bg-gray-100"
+      className="border-gray-250 flex h-52 w-full cursor-pointer gap-6 border-b px-8 py-8 transition hover:bg-gray-100"
     >
       <div className="flex w-full flex-col justify-between">
         <div className="flex flex-col gap-3">

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -20,7 +20,13 @@ function Header() {
       <section className="flex h-16 w-full min-w-170 items-center justify-between px-10 text-lg whitespace-nowrap text-gray-600 md:px-20 xl:px-90">
         <div className="flex items-center gap-15">
           <h1 className="shrink-0">
-            <img className="h-auto w-30 object-contain" src={Logo} alt="logo" />
+            <a href="https://my.ozcodingschool.site">
+              <img
+                className="h-auto w-30 object-contain"
+                src={Logo}
+                alt="logo"
+              />
+            </a>
           </h1>
 
           <nav aria-label="주요 메뉴">

--- a/src/components/editor/EditorHeader.tsx
+++ b/src/components/editor/EditorHeader.tsx
@@ -34,18 +34,20 @@ export default function EditorHeader({
         <div className="flex w-full flex-col gap-5">
           {/* 카테고리 */}
           <div className="flex h-10 w-full items-center">
-            <Dropdown
-              placeholder="카테고리 선택"
-              options={categories.map((c) => c.name)}
-              selected={
-                categories.find((c) => c.id === selectedCategoryId)?.name
-              }
-              onSelect={(value) => {
-                const index = categories.findIndex((c) => c.name === value)
-                if (index === -1) return
-                onChangeCategoryId(categories[index].id)
-              }}
-            />
+            <div className="w-full">
+              <Dropdown
+                placeholder="카테고리 선택"
+                options={categories.map((c) => c.name)}
+                selected={
+                  categories.find((c) => c.id === selectedCategoryId)?.name
+                }
+                onSelect={(value) => {
+                  const index = categories.findIndex((c) => c.name === value)
+                  if (index === -1) return
+                  onChangeCategoryId(categories[index].id)
+                }}
+              />
+            </div>
           </div>
 
           {/* 제목 입력 */}

--- a/src/constants/baseUrl.ts
+++ b/src/constants/baseUrl.ts
@@ -1,4 +1,4 @@
 const MSW_BASE_URL = import.meta.env.VITE_MSW_BASE_URL
-const API_BASE_URL = import.meta.env.VITE_MSW_BASE_URL
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
 
 export { MSW_BASE_URL, API_BASE_URL }

--- a/src/constants/baseUrl.ts
+++ b/src/constants/baseUrl.ts
@@ -1,4 +1,4 @@
 const MSW_BASE_URL = import.meta.env.VITE_MSW_BASE_URL
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
+const API_BASE_URL = import.meta.env.VITE_MSW_BASE_URL
 
 export { MSW_BASE_URL, API_BASE_URL }

--- a/src/hooks/useSlider.ts
+++ b/src/hooks/useSlider.ts
@@ -10,10 +10,14 @@ export function useSlider() {
   useEffect(() => {
     if (!sliderRef.current || !trackRef.current) return
 
-    const observer = new ResizeObserver(() => {
+    const updateSize = () => {
       setSliderWidth(sliderRef.current?.offsetWidth ?? 0)
       setTrackWidth(trackRef.current?.scrollWidth ?? 0)
-    })
+    }
+
+    updateSize()
+
+    const observer = new ResizeObserver(updateSize)
 
     observer.observe(sliderRef.current)
     observer.observe(trackRef.current)
@@ -22,7 +26,7 @@ export function useSlider() {
   }, [])
 
   const minTranslateX = currentPage * sliderWidth
-  const maxTranslateX = Math.max(trackWidth - sliderWidth)
+  const maxTranslateX = Math.max(trackWidth - sliderWidth, 0)
   const translateX = Math.min(minTranslateX, maxTranslateX)
 
   const canSlideLeft = currentPage > 0

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -5,6 +5,8 @@ import {
   updatePostMOCK,
   likePostMOCK,
   unlikePostMOCK,
+  getPostCategoriesMOCK,
+  getPostListMOCK,
 } from './handlers/post-handlers'
 import { commentHandlers } from './handlers/comment-handlers'
 import { getRefreshTokenMOCK } from './handlers/auth-handlers'
@@ -14,11 +16,13 @@ import {
 } from './handlers/image-handlers'
 
 export const handlers = [
+  getPostListMOCK,
   createPostMOCK,
   getPostDetailMOCK,
   updatePostMOCK,
   likePostMOCK,
   unlikePostMOCK,
+  getPostCategoriesMOCK,
   getRefreshTokenMOCK,
   getPresignedUrlMOCK,
   uploadImageToS3MOCK,

--- a/src/mocks/handlers/post-handlers.ts
+++ b/src/mocks/handlers/post-handlers.ts
@@ -29,6 +29,28 @@ export const createPostMOCK = http.post(
   }
 )
 
+// 게시글 목록 조회
+export const getPostListMOCK = http.get(`${MSW_BASE_URL}/posts`, () => {
+  return HttpResponse.json({
+    results: postListData,
+    count: postListData.length,
+  })
+})
+
+// 카테고리 목록 조회
+export const getPostCategoriesMOCK = http.get(
+  `${MSW_BASE_URL}/posts/categories`,
+  () => {
+    return HttpResponse.json({
+      categories: [
+        { id: 1, name: '자유 게시판' },
+        { id: 2, name: '질문 게시판' },
+        { id: 3, name: '구인/협업' },
+      ],
+    })
+  }
+)
+
 // 게시글 상세 조회
 export const getPostDetailMOCK = http.get(
   `${MSW_BASE_URL}/posts/:id`,

--- a/src/mocks/handlers/post-handlers.ts
+++ b/src/mocks/handlers/post-handlers.ts
@@ -3,7 +3,7 @@ import { postListData } from '../data/postListData'
 import type { CreatePostRequest, CreatePostResponse } from '../../types'
 import { MSW_BASE_URL } from '../../constants/baseUrl'
 
-let postPk = 2
+let postPk = 6
 
 // 게시글 생성
 export const createPostMOCK = http.post(
@@ -20,9 +20,39 @@ export const createPostMOCK = http.post(
       return HttpResponse.json({ error_detail: errors }, { status: 400 })
     }
 
+    const categoryMap: Record<number, string> = {
+      1: '구인/협업',
+      2: '자유게시판',
+      3: '공지사항',
+    }
+
+    const newPost = {
+      id: postPk,
+      title: body.title,
+      content: body.content,
+      category: {
+        id: body.category_id,
+        name: categoryMap[body.category_id] ?? '기타',
+      },
+      author: {
+        id: 999,
+        name: '임시유저',
+        profileImage: '',
+      },
+      like_count: 0,
+      is_liked: false,
+      comments: 0,
+      views: 0,
+      createdAt: new Date().toISOString(),
+      imageUrl: null,
+    }
+
+    postListData.unshift(newPost)
+    postPk++
+
     const response: CreatePostResponse = {
       detail: '게시글이 성공적으로 등록되었습니다.',
-      id: postPk++,
+      id: newPost.id,
     }
 
     return HttpResponse.json(response, { status: 201 })
@@ -43,9 +73,9 @@ export const getPostCategoriesMOCK = http.get(
   () => {
     return HttpResponse.json({
       categories: [
-        { id: 1, name: '자유 게시판' },
-        { id: 2, name: '질문 게시판' },
-        { id: 3, name: '구인/협업' },
+        { id: 1, name: '구인/협업' },
+        { id: 2, name: '자유게시판' },
+        { id: 3, name: '공지사항' },
       ],
     })
   }
@@ -92,6 +122,7 @@ export const getPostDetailMOCK = http.get(
       created_at: post.createdAt,
       updated_at: post.createdAt,
       category_id: Number(post.category.id),
+      category_name: post.category.name,
     })
   }
 )
@@ -102,6 +133,17 @@ export const updatePostMOCK = http.put(
   async ({ params, request }) => {
     const postId = Number(params.postId ?? 0)
     const body = (await request.json()) as any
+
+    const post = postListData.find((p: any) => Number(p.id) === postId)
+    if (post) {
+      post.title = body.title
+      post.content = body.content
+      post.category = {
+        id: body.category_id,
+        name: post.category.name,
+      }
+    }
+
     return HttpResponse.json({ id: postId, ...body })
   }
 )

--- a/src/pages/PostList.tsx
+++ b/src/pages/PostList.tsx
@@ -40,7 +40,10 @@ function PostList() {
     ? [{ id: 0, name: '전체' }, ...categoryData]
     : [{ id: 0, name: '전체' }]
 
-  const [currentCategory, setCurrentCategory] = useState(categories[0])
+  const [currentCategory, setCurrentCategory] = useState({
+    id: 0,
+    name: '전체',
+  })
 
   useEffect(() => {
     if (categoryData && categoryData.length > 0) {

--- a/src/pages/PostList.tsx
+++ b/src/pages/PostList.tsx
@@ -170,7 +170,7 @@ function PostList() {
           </div>
         </div>
 
-        <div className="border-gray-250 border-t border-b">
+        <div className="border-gray-250 border-b">
           <div className="flex flex-col">
             {isLoading ? (
               <div className="text-14 text-text-light py-12 text-center">

--- a/src/pages/PostList.tsx
+++ b/src/pages/PostList.tsx
@@ -9,42 +9,6 @@ import { usePosts, usePostCategories } from '../hooks/queries/usePostQueries'
 import CategoryFilterBar from '../components/CategoryFilterBar'
 import { cn } from '../lib/utils'
 
-export interface PostListParams {
-  categoryId?: number
-  sort?: 'latest' | 'oldest' | 'most_views' | 'most_likes' | 'most_comments'
-  search?: string
-  page?: number
-  pageSize?: number
-}
-
-export interface Post {
-  id: number
-  author: {
-    id: number
-    nickname: string
-    profile_img_url: string
-  }
-  category: {
-    id: number
-    name: string
-  }
-  title: string
-  thumbnail_img_url: string | null
-  content_preview: string
-  comment_count: number
-  view_count: number
-  like_count: number
-  created_at: string
-  updated_at: string
-}
-
-export interface PostListResponse {
-  count: number
-  next: string | null
-  previous: string | null
-  results: Post[]
-}
-
 function PostList() {
   const navigate = useNavigate()
 
@@ -86,7 +50,6 @@ function PostList() {
     }
   }, [categoryData, categoryId])
 
-  // 게시글 목록 조회
   const { data, isLoading } = usePosts({
     page,
     page_size: 10,
@@ -95,21 +58,16 @@ function PostList() {
     sort,
   })
 
-  // 실서버 응답 구조(results)에 맞춰 데이터 추출
   const posts = (data as any)?.results ?? []
-
-  // 전체 게시글 수 기반 페이지 계산
   const totalPages = Math.ceil(((data as any)?.count ?? 0) / 10)
 
   return (
     <div className="flex w-full justify-center pt-56">
       <div className="flex w-236 flex-col gap-13">
-        {/* 타이틀 */}
         <h1 className="text-text-main text-3xl leading-10 font-bold">
           커뮤니티
         </h1>
 
-        {/* 검색 영역 */}
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <div className="relative">
@@ -130,7 +88,7 @@ function PostList() {
               </button>
 
               {isSearchTypeOpen && (
-                <div className="absolute top-11 left-0 z-50 flex w-36 flex-col rounded-3xl border border-gray-100 bg-white p-2 shadow-xl outline-none">
+                <div className="absolute top-11 left-0 z-50 -ml-12 flex w-36 flex-col rounded-3xl border border-gray-100 bg-white p-2 shadow-xl outline-none">
                   {searchOptions.map((option) => (
                     <button
                       key={option}
@@ -139,7 +97,7 @@ function PostList() {
                         setIsSearchTypeOpen(false)
                       }}
                       className={cn(
-                        'flex h-12 w-full items-center justify-center rounded-2xl px-4 text-center text-base transition-colors hover:bg-gray-50',
+                        'flex h-12 w-full items-center justify-center rounded-2xl px-2 text-center text-base transition-colors hover:bg-gray-50',
                         searchType === option
                           ? 'text-primary-default bg-purple-50 font-bold'
                           : 'text-text-main'
@@ -157,7 +115,6 @@ function PostList() {
             </div>
           </div>
 
-          {/* 글쓰기 */}
           <Button
             onClick={() => navigate('/posts/create')}
             className="flex h-12 w-30 items-center justify-center gap-2 whitespace-nowrap"
@@ -167,7 +124,6 @@ function PostList() {
           </Button>
         </div>
 
-        {/* 카테고리 + 정렬 */}
         <div className="border-gray-250 flex items-center justify-between border-b pb-3">
           <CategoryFilterBar
             currentCategory={currentCategory}
@@ -178,7 +134,6 @@ function PostList() {
             categoryList={categories}
           />
 
-          {/* 정렬 드롭다운 리스트 */}
           <div className="relative">
             <button
               type="button"
@@ -192,7 +147,7 @@ function PostList() {
             </button>
 
             {isSortOpen && (
-              <div className="absolute top-10 right-0 z-50 flex w-40 flex-col rounded-[24px] border border-gray-100 bg-white p-2 shadow-xl outline-none">
+              <div className="absolute top-10 left-1/2 z-50 flex w-40 -translate-x-[60%] flex-col items-center rounded-[24px] border border-gray-100 bg-white p-2 shadow-xl outline-none">
                 {sortList.map((item) => (
                   <button
                     key={item.value}
@@ -201,7 +156,7 @@ function PostList() {
                       setIsSortOpen(false)
                     }}
                     className={cn(
-                      'flex h-12 w-full items-center justify-center rounded-[16px] px-4 text-center text-base transition-colors',
+                      'flex h-12 w-full items-center justify-center rounded-[16px] px-2 text-base transition-colors',
                       sort === item.value
                         ? 'text-primary-default bg-purple-50 font-bold'
                         : 'text-text-main hover:bg-gray-50'
@@ -215,7 +170,6 @@ function PostList() {
           </div>
         </div>
 
-        {/* 게시글 리스트 */}
         <div className="border-gray-250 border-t border-b">
           <div className="flex flex-col">
             {isLoading ? (
@@ -238,7 +192,6 @@ function PostList() {
           </div>
         </div>
 
-        {/* 페이지네이션 */}
         <div className="mt-3 mb-52">
           <Pagination
             currentPage={page}


### PR DESCRIPTION
## 📌 관련 이슈
closed #108 

## ✨ 변경 내용
- 정렬 모달 버튼 가운데
- 선 2>1 
- 게시글 카드 좌우 패딩
- 프로필 이미지 lucide로
- 게시글 목록 페이지에서 카테고리 메뉴가 렌더링이 안되는 듯함
- 오즈코딩스쿨 로고 클릭하면 https://my.ozcodingschool.site/ 로 넘어가도록 설정

## 📸 스크린샷(선택)
<img width="1538" height="1350" alt="image" src="https://github.com/user-attachments/assets/8c20b51e-1dc5-4f76-82a3-57759b9f49c8" />
<img width="2922" height="1812" alt="image" src="https://github.com/user-attachments/assets/5863fb48-0951-4001-aa44-1ebbb88be103" />


## 📚 참고사항
<!-- 참고할 사항이 있다면 적어주세요. -->
