### PR TITLE
[Refactor] 게시글 카드 카테고리 이름 렌더링

### DIFF
--- a/src/api/postAPI.ts
+++ b/src/api/postAPI.ts
@@ -6,6 +6,7 @@ import type {
   CreatePostResponse,
   PostCategory,
   PostDetailResponse,
+  PostListResponse,
   UpdatePostRequest,
 } from '../types'
 
@@ -18,7 +19,7 @@ async function getPostsAPI(params: {
   category_id?: number
   sort?: 'latest' | 'oldest' | 'most_views' | 'most_likes' | 'most_comments'
 }) {
-  const response = await apiInstance.get('/posts', {
+  const response = await apiInstance.get<PostListResponse>('/posts', {
     params,
   })
   return response.data

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -1,4 +1,5 @@
 import { ThumbsUp, MessageCircle, Eye, User } from 'lucide-react'
+import type { PostListType } from '../types'
 
 export interface PostCardProps {
   id: string
@@ -18,7 +19,7 @@ export interface PostCardProps {
 }
 
 interface Props {
-  post: PostCardProps
+  post: PostListType
   onClick: () => void
 }
 
@@ -45,7 +46,7 @@ function PostCard({ post, onClick }: Props) {
     >
       <div className="flex w-full flex-col justify-between">
         <div className="flex flex-col gap-3">
-          <span className="text-12 text-text-sub">카테고리</span>
+          <span className="text-12 text-text-sub">{post.category_name}</span>
 
           <h3 className="text-16 text-text-main line-clamp-1 font-semibold">
             {post.title}

--- a/src/hooks/usePostList.ts
+++ b/src/hooks/usePostList.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { getPostsAPI, getPostCategoriesAPI } from '../api/postAPI'
-import type { PostCategory } from '../types'
+import type { PostCategory, PostListResponse } from '../types'
 
 export interface PostListParams {
   categoryId?: number
@@ -8,31 +8,6 @@ export interface PostListParams {
   search?: string
   page?: number
   pageSize?: number
-}
-
-export interface Post {
-  id: string
-  author: {
-    id: string
-    nickname: string
-    profile_img_url: string
-  }
-  title: string
-  thumbnail_img_url: string | null
-  content_preview: string
-  comment_count: number
-  view_count: number
-  like_count: number
-  created_at: string
-  updated_at: string
-  category_id: number
-}
-
-export interface PostListResponse {
-  count: number
-  next: string | null
-  previous: string | null
-  results: Post[]
 }
 
 export function useCategoryList() {

--- a/src/pages/PostList.tsx
+++ b/src/pages/PostList.tsx
@@ -8,6 +8,23 @@ import { Button } from '../components/Button'
 import { usePosts, usePostCategories } from '../hooks/queries/usePostQueries'
 import CategoryFilterBar from '../components/CategoryFilterBar'
 import { cn } from '../lib/utils'
+import type { PostListType } from '../types'
+
+const SORT_LIST = [
+  { label: '조회순', value: 'most_views' },
+  { label: '좋아요 순', value: 'most_likes' },
+  { label: '댓글 순', value: 'most_comments' },
+  { label: '최신순', value: 'latest' },
+  { label: '오래된 순', value: 'oldest' },
+]
+
+export interface PostListParams {
+  categoryId?: number
+  sort?: 'latest' | 'oldest' | 'most_views' | 'most_likes' | 'most_comments'
+  search?: string
+  page?: number
+  pageSize?: number
+}
 
 function PostList() {
   const navigate = useNavigate()
@@ -24,16 +41,9 @@ function PostList() {
   const searchOptions = ['제목', '내용', '작성자']
 
   const [isSortOpen, setIsSortOpen] = useState(false)
-  const sortList = [
-    { label: '조회순', value: 'most_views' },
-    { label: '좋아요 순', value: 'most_likes' },
-    { label: '댓글 순', value: 'most_comments' },
-    { label: '최신순', value: 'latest' },
-    { label: '오래된 순', value: 'oldest' },
-  ]
 
   const currentSortLabel =
-    sortList.find((item) => item.value === sort)?.label || '최신순'
+    SORT_LIST.find((item) => item.value === sort)?.label || '최신순'
 
   const { data: categoryData } = usePostCategories()
   const categories = categoryData
@@ -150,8 +160,8 @@ function PostList() {
             </button>
 
             {isSortOpen && (
-              <div className="absolute top-10 left-1/2 z-50 flex w-40 -translate-x-[60%] flex-col items-center rounded-[24px] border border-gray-100 bg-white p-2 shadow-xl outline-none">
-                {sortList.map((item) => (
+              <div className="absolute top-10 right-0 z-50 flex w-40 flex-col rounded-[24px] border border-gray-100 bg-white p-2 shadow-xl outline-none">
+                {SORT_LIST.map((item) => (
                   <button
                     key={item.value}
                     onClick={() => {
@@ -180,7 +190,7 @@ function PostList() {
                 로딩 중...
               </div>
             ) : posts.length > 0 ? (
-              posts.map((post: any) => (
+              posts.map((post: PostListType) => (
                 <PostCard
                   key={post.id}
                   post={post}

--- a/src/types/api-response-types/post.ts
+++ b/src/types/api-response-types/post.ts
@@ -24,3 +24,28 @@ export interface PostDetailResponse {
   created_at: string
   updated_at: string
 }
+
+export interface PostListResponse {
+  count: number
+  next: string | null
+  previous: string | null
+  result: PostListType[]
+}
+
+export type PostListType = {
+  id: number
+  author: {
+    id: number
+    nickname: string
+    profile_img_url: string
+  }
+  title: string
+  thumbnail_img_url: string
+  content_preview: string
+  comment_count: number
+  view_count: number
+  like_count: number
+  created_at: string
+  updated_at: string
+  category_name: string
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #113 

## ✨ 변경 내용
<!-- 변경한 내용을 간략하게 설명해주세요. -->
- 게시글 목록 조회 API 타입 추가 및 분리
- 게시글 카드에 카테고리 이름 렌더링

## 📸 스크린샷(선택)
<!-- 스크린샷이 있다면 첨부해주세요. -->
<img width="1406" height="665" alt="image" src="https://github.com/user-attachments/assets/02b194b2-ccfc-415d-99e5-a84626e0257d" />

## 📚 참고사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 프로필 이미지 데이터가 잘 받아와지는 중인데도 사진처럼 렌더링이 잘 되지 않습니다. 배포에서도 한번 확인해보고 거기서도 이상하면 수정해야 할 것 같습니다!