### PR TITLE
[Feat] 커뮤니티 사이트 진입 시 액세스 토큰 발급

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,14 +9,30 @@ import { useEffect } from 'react'
 import { useAccessTokenStore } from './store/useAccessTokenStore'
 import { useUserInfo } from './hooks/queries/useUserQueries'
 import { useUserInfoStore } from './store/useUserInfoStore'
+import { getRefreshTokenAPI } from './api/authAPI'
 
 function App() {
-  const { accessToken } = useAccessTokenStore()
+  const { accessToken, setAccessToken } = useAccessTokenStore()
   const { setUserInfo } = useUserInfoStore()
   const { data: newUserInfo, isSuccess } = useUserInfo({
     enabled: !!accessToken,
   })
 
+  // 커뮤니티 사이트 진입 시 최초 1번 액세스 토큰 발급
+  useEffect(() => {
+    const getAccessToken = async () => {
+      try {
+        const { access_token: newAccessToken } = await getRefreshTokenAPI()
+        setAccessToken(newAccessToken)
+      } catch {
+        return
+      }
+    }
+
+    getAccessToken()
+  }, [])
+
+  // 액세스 토큰 보유 시 내 정보 조회
   useEffect(() => {
     if (isSuccess) {
       setUserInfo(newUserInfo)

--- a/src/store/useAccessTokenStore.ts
+++ b/src/store/useAccessTokenStore.ts
@@ -11,7 +11,7 @@ export const useAccessTokenStore = create<AccessTokenState>()(
   persist(
     (set) => ({
       // 액세스 토큰 값
-      accessToken: import.meta.env.VITE_TEMPORARY_ACCESS_TOKEN || null,
+      accessToken: null,
 
       setAccessToken: (newToken) => set({ accessToken: newToken }),
 


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #116

## ✨ 변경 내용
<!-- 변경한 내용을 간략하게 설명해주세요. -->
- 커뮤니티 사이트 진입 시 최초 1번 액세스 토큰을 발급받도록 로직 추가

## 📸 스크린샷(선택)
<!-- 스크린샷이 있다면 첨부해주세요. -->

## 📚 참고사항
<!-- 참고할 사항이 있다면 적어주세요. -->
개발 환경에서는 `refresh_token`이 없어 테스트가 불가능합니다.
배포 ci 후 테스트해보겠습니다!